### PR TITLE
Trim down the library API surface

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -136,6 +136,9 @@ lint-manifests:
 lint-rust:
     {{ cargo }} clippy --all-targets --all-features
 
+doc:
+    {{ cargo }} doc --all-features --no-deps --open -p teamtype
+
 [group('test')]
 test *ARGS: (test-cargo ARGS)
 

--- a/crates/e2e-tests/tests/fuzzer.rs
+++ b/crates/e2e-tests/tests/fuzzer.rs
@@ -12,7 +12,7 @@ use e2e_tests::actors::{Actor, Neovim};
 use futures::future::join_all;
 use pretty_assertions::assert_eq;
 use rand::RngExt;
-use teamtype::config::{self, AppConfig};
+use teamtype::config::{self, Config};
 use teamtype::daemon::{Daemon, TEST_FILE_PATH};
 use teamtype::logging;
 use teamtype::sandbox;
@@ -85,21 +85,21 @@ async fn main() -> Result<()> {
     let (_handle2, dir2, file2) = initialize_directory();
 
     // Set up the actors.
-    let mut app_config = AppConfig::default();
-    app_config.base_dir = dir1;
-    let daemon = Daemon::new(app_config, true, false, ui).await?;
+    let mut config = Config::default();
+    config.base_dir = dir1;
+    let daemon = Daemon::new(config, true, false, ui).await?;
 
     // Wait until iroh's DNS discovery (hopefully) works.
     sleep(Duration::from_millis(1000)).await;
 
     let nvim = Neovim::new(Some(file1)).await;
 
-    let mut app_config2 = AppConfig::default();
-    app_config2.base_dir = dir2;
-    app_config2.peer = Some(config::Peer::SecretAddress(
+    let mut config2 = Config::default();
+    config2.base_dir = dir2;
+    config2.peer = Some(config::Peer::SecretAddress(
         daemon.secret_address().to_string(),
     ));
-    let peer = Daemon::new(app_config2, false, false, ui).await?;
+    let peer = Daemon::new(config2, false, false, ui).await?;
 
     // Wait until file2 appears.
     while !file2.exists() {

--- a/crates/e2e-tests/tests/fuzzer.rs
+++ b/crates/e2e-tests/tests/fuzzer.rs
@@ -96,7 +96,9 @@ async fn main() -> Result<()> {
 
     let mut app_config2 = AppConfig::default();
     app_config2.base_dir = dir2;
-    app_config2.peer = Some(config::Peer::SecretAddress(daemon.address.clone()));
+    app_config2.peer = Some(config::Peer::SecretAddress(
+        daemon.secret_address().to_string(),
+    ));
     let peer = Daemon::new(app_config2, false, false, ui).await?;
 
     // Wait until file2 appears.

--- a/crates/e2e-tests/tests/nvim-plugin.rs
+++ b/crates/e2e-tests/tests/nvim-plugin.rs
@@ -25,18 +25,6 @@ async fn plugin_loaded() {
 }
 
 #[tokio::test]
-async fn teamtype_executable_from_nvim() {
-    let nvim = Neovim::new(None).await.nvim;
-    assert_eq!(
-        nvim.command_output(format!("echomsg executable('{TEAMTYPE_DEBUG_BINARY}')").as_str())
-            .await
-            .expect("Failed to run executable() in Neovim"),
-        "1",
-        "Failed to run teamtype executable from Neovim"
-    );
-}
-
-#[tokio::test]
 async fn nvim_sends_something_to_socket() {
     let (nvim, _file_path, mut socket, _dir) = Neovim::new_teamtype_enabled("hi").await;
     dbg!(nvim.content().await);

--- a/crates/teamtype/src/cli_config.rs
+++ b/crates/teamtype/src/cli_config.rs
@@ -6,7 +6,7 @@ use std::env::current_dir;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use teamtype::config::{self, AppConfig};
+use teamtype::config::{self, Config};
 use teamtype::types::UserInterface;
 
 use super::cli::{Cli, Commands, ShareJoinFlags};
@@ -15,7 +15,7 @@ pub async fn parse_join_config(
     command: Commands,
     base_dir: PathBuf,
     ui: &UserInterface,
-) -> Result<AppConfig> {
+) -> Result<Config> {
     if let Commands::Join {
         join_code,
         shared_flags:
@@ -31,7 +31,7 @@ pub async fn parse_join_config(
         ..
     } = command
     {
-        let app_config_cli = AppConfig {
+        let config_cli = Config {
             base_dir,
             peer: join_code.map(config::Peer::JoinCode),
             emit_join_code: false,
@@ -43,18 +43,18 @@ pub async fn parse_join_config(
             sync_vcs,
             username,
         };
-        let mut app_config = AppConfig::from_config_file_and_cli(app_config_cli, ui);
-        app_config = app_config
+        let mut config = Config::from_config_file_and_cli(config_cli, ui);
+        config = config
             .resolve_peer(ui)
             .await
             .context("Failed to resolve peer")?;
-        Ok(app_config)
+        Ok(config)
     } else {
         unreachable!("Only Join commands beget Join configs.")
     }
 }
 
-pub fn parse_share_config(command: Commands, base_dir: PathBuf, ui: &UserInterface) -> AppConfig {
+pub fn parse_share_config(command: Commands, base_dir: PathBuf, ui: &UserInterface) -> Config {
     if let Commands::Share {
         no_join_code,
         shared_flags:
@@ -71,7 +71,7 @@ pub fn parse_share_config(command: Commands, base_dir: PathBuf, ui: &UserInterfa
         ..
     } = command
     {
-        let app_config_cli = AppConfig {
+        let config_cli = Config {
             base_dir,
             peer: None,
             emit_join_code: !no_join_code,
@@ -83,10 +83,10 @@ pub fn parse_share_config(command: Commands, base_dir: PathBuf, ui: &UserInterfa
             sync_vcs,
             username,
         };
-        let mut app_config = AppConfig::from_config_file_and_cli(app_config_cli, ui);
+        let mut config = Config::from_config_file_and_cli(config_cli, ui);
         // Because of the "share" subcommand, explicitly don't connect anywhere.
-        app_config.peer = None;
-        app_config
+        config.peer = None;
+        config
     } else {
         unreachable!("Only Share commands beget Share configs.")
     }

--- a/crates/teamtype/src/cli_config.rs
+++ b/crates/teamtype/src/cli_config.rs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::env::current_dir;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use teamtype::config::{self, AppConfig};
+use teamtype::types::UserInterface;
+
+use super::cli::{Cli, Commands, ShareJoinFlags};
+
+pub async fn parse_join_config(
+    command: Commands,
+    base_dir: PathBuf,
+    ui: &UserInterface,
+) -> Result<AppConfig> {
+    if let Commands::Join {
+        join_code,
+        shared_flags:
+            ShareJoinFlags {
+                magic_wormhole_relay,
+                iroh_relay,
+                iroh_dns_domain,
+                iroh_pkarr_relay,
+                sync_vcs,
+                username,
+                ..
+            },
+        ..
+    } = command
+    {
+        let app_config_cli = AppConfig {
+            base_dir,
+            peer: join_code.map(config::Peer::JoinCode),
+            emit_join_code: false,
+            emit_secret_address: false,
+            magic_wormhole_relay,
+            iroh_relay,
+            iroh_dns_domain,
+            iroh_pkarr_relay,
+            sync_vcs,
+            username,
+        };
+        let mut app_config = AppConfig::from_config_file_and_cli(app_config_cli, ui);
+        app_config = app_config
+            .resolve_peer(ui)
+            .await
+            .context("Failed to resolve peer")?;
+        Ok(app_config)
+    } else {
+        unreachable!("Only Join commands beget Join configs.")
+    }
+}
+
+pub fn parse_share_config(command: Commands, base_dir: PathBuf, ui: &UserInterface) -> AppConfig {
+    if let Commands::Share {
+        no_join_code,
+        shared_flags:
+            ShareJoinFlags {
+                magic_wormhole_relay,
+                iroh_relay,
+                iroh_dns_domain,
+                iroh_pkarr_relay,
+                sync_vcs,
+                username,
+                ..
+            },
+        show_secret_address,
+        ..
+    } = command
+    {
+        let app_config_cli = AppConfig {
+            base_dir,
+            peer: None,
+            emit_join_code: !no_join_code,
+            emit_secret_address: show_secret_address,
+            magic_wormhole_relay,
+            iroh_relay,
+            iroh_dns_domain,
+            iroh_pkarr_relay,
+            sync_vcs,
+            username,
+        };
+        let mut app_config = AppConfig::from_config_file_and_cli(app_config_cli, ui);
+        // Because of the "share" subcommand, explicitly don't connect anywhere.
+        app_config.peer = None;
+        app_config
+    } else {
+        unreachable!("Only Share commands beget Share configs.")
+    }
+}
+
+pub fn parse_directory_config(cli: &Cli) -> Result<Option<PathBuf>> {
+    match cli.command {
+        Commands::Share {
+            shared_flags:
+                ShareJoinFlags {
+                    temporary_directory,
+                    ..
+                },
+            ..
+        }
+        | Commands::Join {
+            shared_flags:
+                ShareJoinFlags {
+                    temporary_directory,
+                    ..
+                },
+            ..
+        } => {
+            if temporary_directory {
+                return Ok(None);
+            }
+        }
+        Commands::Client => {}
+    }
+    let directory = match cli.directory {
+        Some(ref directory) => directory,
+        None => &current_dir().context("Could not access current directory")?,
+    };
+    Ok(Some(directory.clone()))
+}

--- a/crates/teamtype/src/client.rs
+++ b/crates/teamtype/src/client.rs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+use crate::jsonrpc_forwarder::{JSONRPCForwarder, UnixJSONRPCForwarder};
+
+pub async fn run_client(directory: PathBuf) -> Result<()> {
+    let jsonrpc_forwarder = UnixJSONRPCForwarder {};
+    jsonrpc_forwarder
+        .connection(&directory)
+        .await
+        .context("JSON-RPC forwarder failed")
+}

--- a/crates/teamtype/src/config.rs
+++ b/crates/teamtype/src/config.rs
@@ -36,7 +36,7 @@ pub enum Peer {
 
 #[derive(Clone, Default, Debug)]
 #[must_use]
-pub struct AppConfig {
+pub struct Config {
     pub base_dir: PathBuf,
     pub peer: Option<Peer>,
     pub emit_join_code: bool,
@@ -50,15 +50,15 @@ pub struct AppConfig {
     pub username: Option<String>,
 }
 
-impl AppConfig {
+impl Config {
     // Merges the app config from file with the CLI app config by taking the "superset" of them.
     //
     // It depends on the attribute how we're merging it:
     // - For strings, the CLI app config attribute has precedence.
     // - For booleans, if a value deviates from the default, it "wins".
     // - The `base_dir` will be taken from the CLI app config.
-    pub fn from_config_file_and_cli(app_config_cli: Self, ui: &UserInterface) -> Self {
-        let base_dir = app_config_cli.base_dir;
+    pub fn from_config_file_and_cli(config_cli: Self, ui: &UserInterface) -> Self {
+        let base_dir = config_cli.base_dir;
         let config_file = base_dir.join(CONFIG_DIR).join(CONFIG_FILE);
         let empty_properties_section = Properties::new();
         let conf;
@@ -72,24 +72,24 @@ impl AppConfig {
 
         // we do the computation of username before initializing the struct, because we need to
         // reference base_dir, which gets moved during the initialization of the struct
-        let username = get_username(app_config_cli.username, &base_dir, general_section, ui);
+        let username = get_username(config_cli.username, &base_dir, general_section, ui);
         Self {
             // TODO: extract all the other fields to its own struct, s.t. we don't have to work
             // around the fact that base_dir won't ever be in the config file.
             base_dir,
-            peer: app_config_cli.peer.or_else(|| {
+            peer: config_cli.peer.or_else(|| {
                 general_section
                     .get("peer")
                     .map(|p| Peer::SecretAddress(p.to_string()))
             }),
-            emit_join_code: app_config_cli.emit_join_code
+            emit_join_code: config_cli.emit_join_code
                 && general_section
                     .get("emit_join_code")
                     .map_or(EMIT_JOIN_CODE_DEFAULT, |ejc| {
                         ejc.parse()
                             .expect("Failed to parse config parameter `emit_join_code` as bool")
                     }),
-            emit_secret_address: app_config_cli.emit_secret_address
+            emit_secret_address: config_cli.emit_secret_address
                 || general_section.get("emit_secret_address").map_or(
                     EMIT_SECRET_ADDRESS_DEFAULT,
                     |esa| {
@@ -98,25 +98,25 @@ impl AppConfig {
                         )
                     },
                 ),
-            magic_wormhole_relay: app_config_cli.magic_wormhole_relay.or_else(|| {
+            magic_wormhole_relay: config_cli.magic_wormhole_relay.or_else(|| {
                 general_section
                     .get("magic_wormhole_relay")
                     .map(ToString::to_string)
             }),
-            iroh_relay: app_config_cli
+            iroh_relay: config_cli
                 .iroh_relay
                 .or_else(|| general_section.get("iroh_relay").map(ToString::to_string)),
-            iroh_dns_domain: app_config_cli.iroh_dns_domain.or_else(|| {
+            iroh_dns_domain: config_cli.iroh_dns_domain.or_else(|| {
                 general_section
                     .get("iroh_dns_domain")
                     .map(ToString::to_string)
             }),
-            iroh_pkarr_relay: app_config_cli.iroh_pkarr_relay.or_else(|| {
+            iroh_pkarr_relay: config_cli.iroh_pkarr_relay.or_else(|| {
                 general_section
                     .get("iroh_pkarr_relay")
                     .map(ToString::to_string)
             }),
-            sync_vcs: app_config_cli.sync_vcs,
+            sync_vcs: config_cli.sync_vcs,
             username: Some(username),
         }
     }
@@ -211,12 +211,12 @@ pub(crate) fn has_local_user_config(base_dir: &Path) -> Result<bool> {
 }
 
 fn get_username(
-    app_config_cli_username: Option<String>,
+    config_cli_username: Option<String>,
     base_dir: &Path,
     general_section: &Properties,
     ui: &UserInterface,
 ) -> String {
-    app_config_cli_username
+    config_cli_username
         .map(|u| get_username_from_cli(u, ui))
         .or_else(|| get_username_from_config_file(general_section, ui))
         .or_else(|| get_username_from_git(base_dir, ui))

--- a/crates/teamtype/src/config.rs
+++ b/crates/teamtype/src/config.rs
@@ -20,7 +20,7 @@ use crate::types::UserInterface;
 use crate::wormhole::get_secret_address_from_wormhole;
 
 pub(crate) const DEFAULT_SOCKET_NAME: &str = "socket";
-pub const CONFIG_DIR: &str = ".teamtype";
+pub(crate) const CONFIG_DIR: &str = ".teamtype";
 pub(crate) const CONFIG_FILE: &str = "config";
 
 const EMIT_JOIN_CODE_DEFAULT: bool = true;
@@ -177,7 +177,7 @@ fn store_peer_in_config(
 }
 
 #[must_use]
-pub fn has_git_remote(path: &Path) -> bool {
+pub(crate) fn has_git_remote(path: &Path) -> bool {
     if let Ok(repo) = find_git_repo(path)
         && let Ok(remotes) = repo.remotes()
     {
@@ -198,7 +198,7 @@ fn teamtype_directory_should_be_ignored_but_isnt(path: &Path) -> bool {
 }
 
 /// Test if the local Git config has *any* user config.
-pub fn has_local_user_config(base_dir: &Path) -> Result<bool> {
+pub(crate) fn has_local_user_config(base_dir: &Path) -> Result<bool> {
     let snapshot = find_git_repo(base_dir)?.config()?.snapshot()?;
     let mut entries = snapshot.entries(Some("user\\."))?;
     while let Some(Ok(entry)) = entries.next() {
@@ -317,7 +317,7 @@ fn add_teamtype_to_local_gitignore(directory: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn ensure_teamtype_is_ignored(directory: &Path) -> Result<()> {
+pub(crate) fn ensure_teamtype_is_ignored(directory: &Path) -> Result<()> {
     if teamtype_directory_should_be_ignored_but_isnt(directory) {
         add_teamtype_to_local_gitignore(directory)?;
     }

--- a/crates/teamtype/src/config.rs
+++ b/crates/teamtype/src/config.rs
@@ -19,11 +19,9 @@ use crate::sandbox;
 use crate::types::UserInterface;
 use crate::wormhole::get_secret_address_from_wormhole;
 
-pub const DOC_FILE: &str = "doc";
 pub const DEFAULT_SOCKET_NAME: &str = "socket";
 pub const CONFIG_DIR: &str = ".teamtype";
 pub const CONFIG_FILE: &str = "config";
-pub const BOOKMARK_FILE: &str = "bookmark";
 
 const EMIT_JOIN_CODE_DEFAULT: bool = true;
 const EMIT_SECRET_ADDRESS_DEFAULT: bool = false;

--- a/crates/teamtype/src/config.rs
+++ b/crates/teamtype/src/config.rs
@@ -19,9 +19,9 @@ use crate::sandbox;
 use crate::types::UserInterface;
 use crate::wormhole::get_secret_address_from_wormhole;
 
-pub const DEFAULT_SOCKET_NAME: &str = "socket";
+pub(crate) const DEFAULT_SOCKET_NAME: &str = "socket";
 pub const CONFIG_DIR: &str = ".teamtype";
-pub const CONFIG_FILE: &str = "config";
+pub(crate) const CONFIG_FILE: &str = "config";
 
 const EMIT_JOIN_CODE_DEFAULT: bool = true;
 const EMIT_SECRET_ADDRESS_DEFAULT: bool = false;
@@ -158,12 +158,12 @@ impl AppConfig {
     }
 
     #[must_use]
-    pub const fn is_host(&self) -> bool {
+    pub(crate) const fn is_host(&self) -> bool {
         self.peer.is_none()
     }
 }
 
-pub fn store_peer_in_config(
+fn store_peer_in_config(
     directory: &Path,
     config_file: &Path,
     peer: &str,
@@ -269,7 +269,7 @@ fn get_username_from_fallback_value(ui: &UserInterface) -> String {
 }
 
 #[must_use]
-pub fn get_git_username(base_dir: &Path) -> Option<String> {
+fn get_git_username(base_dir: &Path) -> Option<String> {
     local_git_username(base_dir)
         .or_else(|_| global_git_username())
         .ok()

--- a/crates/teamtype/src/daemon.rs
+++ b/crates/teamtype/src/daemon.rs
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use std::collections::{HashMap, HashSet};
-use std::fmt;
+use std::fmt::{self, Debug, Formatter};
 use std::iter::repeat_with;
 use std::path::{Path, PathBuf};
 use std::sync::{
@@ -110,8 +110,8 @@ pub(crate) enum DocMessage {
     ReceiveEphemeral(EphemeralMessage),
 }
 
-impl fmt::Debug for DocMessage {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Debug for DocMessage {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let repr = match self {
             Self::GetContent { .. } => "GetContent".to_string(),
             Self::FromEditor(id, m) => format!("FromEditor({id}, {m:?})"),

--- a/crates/teamtype/src/daemon.rs
+++ b/crates/teamtype/src/daemon.rs
@@ -30,7 +30,7 @@ use tokio::{
 };
 use tracing::debug;
 
-use crate::config::{self, AppConfig};
+use crate::config::{self, Config};
 use crate::document::{self, Document};
 use crate::editor::{self, EditorId, EditorWriter};
 use crate::editor_connection::EditorConnection;
@@ -52,12 +52,8 @@ use crate::wormhole::put_secret_address_into_wormhole;
 
 pub const TEST_FILE_PATH: &str = "text";
 
-pub async fn run_daemon(
-    app_config: AppConfig,
-    init_doc: bool,
-    ui: &UserInterface,
-) -> Result<Daemon> {
-    let persist = !config::has_git_remote(&app_config.base_dir);
+pub async fn run_daemon(config: Config, init_doc: bool, ui: &UserInterface) -> Result<Daemon> {
+    let persist = !config::has_git_remote(&config.base_dir);
     if !persist {
         // TODO: drop .teamtype/doc here? Would that be rude?
         ui.log(
@@ -65,9 +61,9 @@ pub async fn run_daemon(
         );
     }
 
-    config::ensure_teamtype_is_ignored(&app_config.base_dir)?;
+    config::ensure_teamtype_is_ignored(&config.base_dir)?;
 
-    if app_config.sync_vcs && config::has_local_user_config(&app_config.base_dir).is_ok_and(|v| v) {
+    if config.sync_vcs && config::has_local_user_config(&config.base_dir).is_ok_and(|v| v) {
         ui.warn(docstr!(
             /// You have a local user configuration in your .git/config.
             /// In --sync-vcs mode, this file will also be synchronized between peers.
@@ -79,7 +75,7 @@ pub async fn run_daemon(
     // Setup a new daemon from the derived config. Immediately join the handle because that's what
     // actually starts the local socket and any configured network connections. Return the result
     // so the calling context can determine when to terminate.
-    Daemon::new(app_config, init_doc, persist, ui)
+    Daemon::new(config, init_doc, persist, ui)
         .await
         .context("Failed to launch the daemon")
 }
@@ -148,7 +144,7 @@ struct DocumentActor {
     ephemeral_states: HashMap<CursorId, EphemeralMessage>,
     /// The Document is the main I/O managed resource of this actor.
     crdt_doc: Document,
-    app_config: AppConfig,
+    config: Config,
     ui: UserInterface,
     save_fully: bool,
 }
@@ -158,15 +154,15 @@ impl DocumentActor {
         doc_message_rx: mpsc::Receiver<DocMessage>,
         doc_changed_ping_tx: DocChangedSender,
         ephemeral_message_tx: EphemeralMessageSender,
-        app_config: AppConfig,
+        config: Config,
         ui: &UserInterface,
         init: bool,
         persist: bool,
     ) -> Self {
         // If there is a persisted version in base_dir/.teamtype/doc, load it.
         // TODO: Pull out ".teamtype" string into a constant.
-        let persistence_file = app_config.base_dir.join(".teamtype/doc");
-        let persistence_file_exists = sandbox::exists(&app_config.base_dir, &persistence_file)
+        let persistence_file = config.base_dir.join(".teamtype/doc");
+        let persistence_file_exists = sandbox::exists(&config.base_dir, &persistence_file)
             .expect("Could not check for the existence of the persistence file");
 
         let load_crdt_doc = persistence_file_exists && !init && persist;
@@ -175,7 +171,7 @@ impl DocumentActor {
                 "Loading persisted CRDT document from '{}'.",
                 persistence_file.display()
             );
-            let bytes = sandbox::read_file(&app_config.base_dir, &persistence_file)
+            let bytes = sandbox::read_file(&config.base_dir, &persistence_file)
                 .unwrap_or_else(|_| panic!("Could not read file '{}'", persistence_file.display()));
             Document::load(&bytes, ui)
         } else {
@@ -189,7 +185,7 @@ impl DocumentActor {
             ephemeral_message_tx,
             editor_connections: HashMap::default(),
             ephemeral_states: HashMap::default(),
-            app_config,
+            config,
             ui: ui.clone(),
             crdt_doc,
             save_fully: true,
@@ -197,7 +193,7 @@ impl DocumentActor {
 
         if persistence_file_exists && persist {
             s.read_current_content_from_dir(init);
-        } else if s.app_config.is_host() {
+        } else if s.config.is_host() {
             s.read_current_content_from_dir(true);
         }
 
@@ -245,11 +241,11 @@ impl DocumentActor {
                 self.read_current_content_from_dir(false);
             }
             DocMessage::Persist => {
-                let persistence_file = self.app_config.base_dir.join(".teamtype/doc");
+                let persistence_file = self.config.base_dir.join(".teamtype/doc");
                 if self.save_fully {
                     debug!("Persisting CRDT document fully.");
                     let bytes = self.crdt_doc.save();
-                    sandbox::write_file(&self.app_config.base_dir, &persistence_file, &bytes)
+                    sandbox::write_file(&self.config.base_dir, &persistence_file, &bytes)
                         .unwrap_or_else(|_| {
                             panic!("Failed to persist to '{}'", persistence_file.display())
                         });
@@ -257,7 +253,7 @@ impl DocumentActor {
                 } else {
                     debug!("Persisting CRDT document incrementally.");
                     let bytes = self.crdt_doc.save_incremental();
-                    sandbox::append_file(&self.app_config.base_dir, &persistence_file, &bytes)
+                    sandbox::append_file(&self.config.base_dir, &persistence_file, &bytes)
                         .unwrap_or_else(|_| {
                             panic!("Failed to persist to '{}'", persistence_file.display())
                         });
@@ -286,7 +282,7 @@ impl DocumentActor {
                                 self.ui.inform(&format!("Removing file {file_path}."));
 
                                 sandbox::remove_file(
-                                    &self.app_config.base_dir,
+                                    &self.config.base_dir,
                                     &self.absolute_path_for_file_path(&file_path),
                                 )
                                 .unwrap_or_else(|err| {
@@ -373,7 +369,7 @@ impl DocumentActor {
                 self.editor_connections.insert(
                     id,
                     (
-                        EditorConnection::new(editor_connection_id, self.app_config.clone()),
+                        EditorConnection::new(editor_connection_id, self.config.clone()),
                         editor_writer,
                     ),
                 );
@@ -401,7 +397,7 @@ impl DocumentActor {
     }
 
     fn absolute_path_for_file_path(&self, file_path: &RelativePath) -> AbsolutePath {
-        AbsolutePath::from_parts(&self.app_config.base_dir, file_path)
+        AbsolutePath::from_parts(&self.config.base_dir, file_path)
             .expect("base_dir should be absolute")
     }
 
@@ -486,7 +482,7 @@ impl DocumentActor {
 
     fn handle_watcher_event(&mut self, watcher_event: &WatcherEvent) {
         let relative_file_path =
-            RelativePath::try_from_path(&self.app_config.base_dir, &watcher_event.file_path)
+            RelativePath::try_from_path(&self.config.base_dir, &watcher_event.file_path)
                 .expect("Watcher event should have a path within the base directory");
 
         if self.owns(&relative_file_path) {
@@ -511,7 +507,7 @@ impl DocumentActor {
     // contains the file already in the `update_text` method anyway.
     fn file_created_or_changed(&mut self, relative_file_path: &RelativePath) {
         let file_path = self.absolute_path_for_file_path(relative_file_path);
-        let new_content = match sandbox::read_file(&self.app_config.base_dir, &file_path) {
+        let new_content = match sandbox::read_file(&self.config.base_dir, &file_path) {
             Ok(content) => content,
             Err(e) => {
                 self.ui.warn(&format!(
@@ -621,7 +617,7 @@ impl DocumentActor {
 
     fn ensure_file_has_bytes(&self, file_path: &RelativePath, bytes: &[u8]) {
         let abs_path = self.absolute_path_for_file_path(file_path);
-        if sandbox::exists(&self.app_config.base_dir, &abs_path)
+        if sandbox::exists(&self.config.base_dir, &abs_path)
             .expect("Failed to check for file existence before writing to it")
         {
             // Special case: If we want to write a .git/objects/... file, and there's one already
@@ -633,7 +629,7 @@ impl DocumentActor {
                 return;
             }
 
-            if let Ok(current_bytes) = sandbox::read_file(&self.app_config.base_dir, &abs_path) {
+            if let Ok(current_bytes) = sandbox::read_file(&self.config.base_dir, &abs_path) {
                 if bytes == current_bytes {
                     debug!("File content is already the desired one, not writing.");
                     return;
@@ -645,17 +641,17 @@ impl DocumentActor {
             self.ui.inform(&format!("Creating file {file_path}."));
         }
 
-        sandbox::write_file(&self.app_config.base_dir, &abs_path, bytes)
+        sandbox::write_file(&self.config.base_dir, &abs_path, bytes)
             .unwrap_or_else(|err| panic!("Failed to write to file {abs_path}: {err}"));
     }
 
     fn read_current_content_from_dir(&mut self, init: bool) {
         debug!("Reading current contents from disk (init: {init}).");
-        for file_path in sandbox::enumerate_non_ignored_files(&self.app_config) {
-            match sandbox::read_file(&self.app_config.base_dir, &file_path) {
+        for file_path in sandbox::enumerate_non_ignored_files(&self.config) {
+            match sandbox::read_file(&self.config.base_dir, &file_path) {
                 Ok(bytes) => {
                     let relative_file_path =
-                        RelativePath::try_from_path(&self.app_config.base_dir, &file_path)
+                        RelativePath::try_from_path(&self.config.base_dir, &file_path)
                             .expect("Walked file path should be within base directory");
                     if self.owns(&relative_file_path) {
                         if let Ok(text) = String::from_utf8(bytes.clone()) {
@@ -684,7 +680,7 @@ impl DocumentActor {
 
         for relative_file_path in self.crdt_doc.files() {
             let absolute_file_path = self.absolute_path_for_file_path(&relative_file_path);
-            if !sandbox::exists(&self.app_config.base_dir, &absolute_file_path)
+            if !sandbox::exists(&self.config.base_dir, &absolute_file_path)
                 .expect(
                     "Should have been able to check for file existence while reading current directory content"
                 )
@@ -912,7 +908,7 @@ pub struct DocumentActorHandle {
 }
 
 impl DocumentActorHandle {
-    fn new(app_config: &AppConfig, ui: &UserInterface, init: bool, persist: bool) -> Self {
+    fn new(config: &Config, ui: &UserInterface, init: bool, persist: bool) -> Self {
         // The document task will receive messages on this channel.
         let (doc_message_tx, doc_message_rx) = mpsc::channel(1);
 
@@ -928,7 +924,7 @@ impl DocumentActorHandle {
             doc_message_rx,
             doc_changed_ping_tx.clone(),
             ephemeral_message_tx.clone(),
-            app_config.clone(),
+            config.clone(),
             ui,
             init,
             persist,
@@ -988,7 +984,7 @@ impl DocumentActorHandle {
 pub struct Daemon {
     pub document_handle: DocumentActorHandle,
     socket_path: PathBuf,
-    app_config: AppConfig,
+    config: Config,
     // We need to store the connection manager in order to keep the connection alive.
     connection_manager: peer::ConnectionManager,
 }
@@ -996,16 +992,16 @@ pub struct Daemon {
 impl Daemon {
     // Launch the daemon. Optionally, connect to given peer.
     pub async fn new(
-        app_config: AppConfig,
+        config: Config,
         init: bool,
         persist: bool,
         ui: &UserInterface,
     ) -> Result<Self> {
-        debug!("Starting Teamtype on {}.", app_config.base_dir.display());
+        debug!("Starting Teamtype on {}.", config.base_dir.display());
 
-        let document_handle = DocumentActorHandle::new(&app_config, ui, init, persist);
+        let document_handle = DocumentActorHandle::new(&config, ui, init, persist);
 
-        let base_dir = &app_config.base_dir;
+        let base_dir = &config.base_dir;
 
         // Start socket listener.
         let socket_path = base_dir
@@ -1014,7 +1010,7 @@ impl Daemon {
         editor::spawn_socket_listener(&socket_path, document_handle.clone(), ui)?;
 
         // Start file watcher.
-        spawn_file_watcher(&app_config, document_handle.clone());
+        spawn_file_watcher(&config, document_handle.clone());
 
         if persist {
             // Start persister.
@@ -1023,12 +1019,12 @@ impl Daemon {
 
         // Start connection manager.
         let connection_manager =
-            peer::ConnectionManager::new(&app_config, document_handle.clone(), base_dir, ui)
+            peer::ConnectionManager::new(&config, document_handle.clone(), base_dir, ui)
                 .await
                 .expect("Failed to start connection manager");
         let address = connection_manager.secret_address();
 
-        if app_config.emit_secret_address {
+        if config.emit_secret_address {
             ui.inform(&docstr!(format!
                 /// Others can connect by putting the following secret address in their .teamtype/config:
                 ///
@@ -1036,11 +1032,11 @@ impl Daemon {
                 ///
             ));
         }
-        if app_config.emit_join_code {
-            put_secret_address_into_wormhole(address, app_config.magic_wormhole_relay.clone(), ui)
+        if config.emit_join_code {
+            put_secret_address_into_wormhole(address, config.magic_wormhole_relay.clone(), ui)
                 .await;
         }
-        if let Some(config::Peer::SecretAddress(ref secret_address)) = app_config.peer {
+        if let Some(config::Peer::SecretAddress(ref secret_address)) = config.peer {
             connection_manager
                 .connect(secret_address.clone())
                 .await
@@ -1050,7 +1046,7 @@ impl Daemon {
         Ok(Self {
             document_handle,
             socket_path,
-            app_config,
+            config,
             connection_manager,
         })
     }
@@ -1063,7 +1059,7 @@ impl Daemon {
 impl Drop for Daemon {
     fn drop(&mut self) {
         debug!("Daemon dropped, removing socket");
-        sandbox::remove_file(Path::new(&self.app_config.base_dir), &self.socket_path)
+        sandbox::remove_file(Path::new(&self.config.base_dir), &self.socket_path)
             .expect("Could not remove socket");
     }
 }
@@ -1071,8 +1067,8 @@ impl Drop for Daemon {
 // Spawn a file watcher and feed its events to the document_handle.
 // In addition, a short timeout after the last event, do a full re-scan, so that we don't miss any
 // file changes - the watcher isn't necessarily exhaustive.
-fn spawn_file_watcher(app_config: &AppConfig, document_handle: DocumentActorHandle) {
-    let mut event_rx = Watcher::spawn(app_config.clone());
+fn spawn_file_watcher(config: &Config, document_handle: DocumentActorHandle) {
+    let mut event_rx = Watcher::spawn(config.clone());
 
     tokio::spawn(async move {
         let debounce_duration = Duration::from_millis(100);
@@ -1173,7 +1169,7 @@ mod tests {
                     doc_message_rx,
                     doc_changed_ping_tx,
                     ephemeral_message_tx,
-                    AppConfig {
+                    Config {
                         base_dir: directory.path().to_path_buf(),
                         ..Default::default()
                     },

--- a/crates/teamtype/src/daemon.rs
+++ b/crates/teamtype/src/daemon.rs
@@ -52,6 +52,38 @@ use crate::wormhole::put_secret_address_into_wormhole;
 
 pub const TEST_FILE_PATH: &str = "text";
 
+pub async fn run_daemon(
+    app_config: AppConfig,
+    init_doc: bool,
+    ui: &UserInterface,
+) -> Result<Daemon> {
+    let persist = !config::has_git_remote(&app_config.base_dir);
+    if !persist {
+        // TODO: drop .teamtype/doc here? Would that be rude?
+        ui.log(
+            "Detected a Git remote: Assuming a pair-programming use-case and starting a new history."
+        );
+    }
+
+    config::ensure_teamtype_is_ignored(&app_config.base_dir)?;
+
+    if app_config.sync_vcs && config::has_local_user_config(&app_config.base_dir).is_ok_and(|v| v) {
+        ui.warn(docstr!(
+            /// You have a local user configuration in your .git/config.
+            /// In --sync-vcs mode, this file will also be synchronized between peers.
+            /// If your version "wins", all peers will have the same Git identity.
+            /// As a workaround, you could use `git commit --author`.
+        ));
+    }
+
+    // Setup a new daemon from the derived config. Immediately join the handle because that's what
+    // actually starts the local socket and any configured network connections. Return the result
+    // so the calling context can determine when to terminate.
+    Daemon::new(app_config, init_doc, persist, ui)
+        .await
+        .context("Failed to launch the daemon")
+}
+
 // These messages are sent to the task that owns the document.
 #[must_use]
 pub(crate) enum DocMessage {

--- a/crates/teamtype/src/daemon.rs
+++ b/crates/teamtype/src/daemon.rs
@@ -154,7 +154,6 @@ struct DocumentActor {
 }
 
 impl DocumentActor {
-    #[expect(clippy::too_many_arguments)]
     fn new(
         doc_message_rx: mpsc::Receiver<DocMessage>,
         doc_changed_ping_tx: DocChangedSender,
@@ -162,7 +161,6 @@ impl DocumentActor {
         app_config: AppConfig,
         ui: &UserInterface,
         init: bool,
-        is_host: bool,
         persist: bool,
     ) -> Self {
         // If there is a persisted version in base_dir/.teamtype/doc, load it.
@@ -199,7 +197,7 @@ impl DocumentActor {
 
         if persistence_file_exists && persist {
             s.read_current_content_from_dir(init);
-        } else if is_host {
+        } else if s.app_config.is_host() {
             s.read_current_content_from_dir(true);
         }
 
@@ -914,13 +912,7 @@ pub struct DocumentActorHandle {
 }
 
 impl DocumentActorHandle {
-    fn new(
-        app_config: &AppConfig,
-        ui: &UserInterface,
-        init: bool,
-        is_host: bool,
-        persist: bool,
-    ) -> Self {
+    fn new(app_config: &AppConfig, ui: &UserInterface, init: bool, persist: bool) -> Self {
         // The document task will receive messages on this channel.
         let (doc_message_tx, doc_message_rx) = mpsc::channel(1);
 
@@ -939,7 +931,6 @@ impl DocumentActorHandle {
             app_config.clone(),
             ui,
             init,
-            is_host,
             persist,
         );
 
@@ -1012,9 +1003,7 @@ impl Daemon {
     ) -> Result<Self> {
         debug!("Starting Teamtype on {}.", app_config.base_dir.display());
 
-        let is_host = app_config.is_host();
-
-        let document_handle = DocumentActorHandle::new(&app_config, ui, init, is_host, persist);
+        let document_handle = DocumentActorHandle::new(&app_config, ui, init, persist);
 
         let base_dir = &app_config.base_dir;
 
@@ -1189,7 +1178,6 @@ mod tests {
                         ..Default::default()
                     },
                     ui,
-                    true,
                     true,
                     false,
                 )

--- a/crates/teamtype/src/daemon.rs
+++ b/crates/teamtype/src/daemon.rs
@@ -964,10 +964,8 @@ impl DocumentActorHandle {
 #[must_use]
 pub struct Daemon {
     pub document_handle: DocumentActorHandle,
-    _address: String,
     socket_path: PathBuf,
     app_config: AppConfig,
-    #[expect(dead_code)]
     // We need to store the connection manager in order to keep the connection alive.
     connection_manager: peer::ConnectionManager,
 }
@@ -1030,11 +1028,14 @@ impl Daemon {
 
         Ok(Self {
             document_handle,
-            _address: address.to_owned(),
             socket_path,
             app_config,
             connection_manager,
         })
+    }
+
+    pub fn secret_address(&self) -> &str {
+        self.connection_manager.secret_address()
     }
 }
 

--- a/crates/teamtype/src/daemon.rs
+++ b/crates/teamtype/src/daemon.rs
@@ -54,7 +54,7 @@ pub const TEST_FILE_PATH: &str = "text";
 
 // These messages are sent to the task that owns the document.
 #[must_use]
-pub enum DocMessage {
+pub(crate) enum DocMessage {
     GetContent {
         response_tx: oneshot::Sender<Option<document::Content>>,
     },
@@ -108,7 +108,7 @@ type EphemeralMessageReceiver = broadcast::Receiver<EphemeralMessage>;
 ///
 /// Any `DocMessage` that is emitted via `DocumentActorHandle` should have an effect eventually.
 #[must_use]
-pub struct DocumentActor {
+struct DocumentActor {
     doc_message_rx: mpsc::Receiver<DocMessage>,
     doc_changed_ping_tx: DocChangedSender,
     ephemeral_message_tx: EphemeralMessageSender,
@@ -882,7 +882,7 @@ pub struct DocumentActorHandle {
 }
 
 impl DocumentActorHandle {
-    pub fn new(
+    fn new(
         app_config: &AppConfig,
         ui: &UserInterface,
         init: bool,
@@ -922,7 +922,7 @@ impl DocumentActorHandle {
     }
 
     /// The TCP and socket connections will send messages through this when they receive something.
-    pub async fn send_message(&self, message: DocMessage) {
+    pub(crate) async fn send_message(&self, message: DocMessage) {
         self.doc_message_tx
             .send(message)
             .await
@@ -930,12 +930,12 @@ impl DocumentActorHandle {
     }
 
     #[must_use]
-    pub fn subscribe_document_changes(&self) -> DocChangedReceiver {
+    pub(crate) fn subscribe_document_changes(&self) -> DocChangedReceiver {
         self.doc_changed_ping_tx.subscribe()
     }
 
     #[must_use]
-    pub fn subscribe_ephemeral_messages(&self) -> EphemeralMessageReceiver {
+    pub(crate) fn subscribe_ephemeral_messages(&self) -> EphemeralMessageReceiver {
         self.ephemeral_message_tx.subscribe()
     }
 
@@ -956,7 +956,7 @@ impl DocumentActorHandle {
     }
 
     #[must_use]
-    pub fn next_editor_id(&self) -> EditorId {
+    pub(crate) fn next_editor_id(&self) -> EditorId {
         self.next_id.fetch_add(1, Ordering::Relaxed)
     }
 }
@@ -964,7 +964,7 @@ impl DocumentActorHandle {
 #[must_use]
 pub struct Daemon {
     pub document_handle: DocumentActorHandle,
-    pub address: String,
+    _address: String,
     socket_path: PathBuf,
     app_config: AppConfig,
     #[expect(dead_code)]
@@ -1030,7 +1030,7 @@ impl Daemon {
 
         Ok(Self {
             document_handle,
-            address: address.to_owned(),
+            _address: address.to_owned(),
             socket_path,
             app_config,
             connection_manager,

--- a/crates/teamtype/src/document.rs
+++ b/crates/teamtype/src/document.rs
@@ -192,7 +192,6 @@ impl Document {
         self.files.get(file_path)
     }
 
-    // TODO: Refactor such that file_content_at can also return bytes (and get rid of get_bytes_at)
     pub fn file_content_at(
         &self,
         file_path: &RelativePath,
@@ -203,26 +202,6 @@ impl Document {
                 .text_at(to, heads)
                 .expect("Failed to get string from Automerge text object")
         })
-    }
-
-    /// Used to get the contents of a binary file at a specific state.
-    pub fn get_bytes_at(&self, file_path: &RelativePath, heads: &[ChangeHash]) -> Result<Vec<u8>> {
-        let file_map = self
-            .top_level_map_obj("files")
-            .expect("Failed to get files Map object");
-
-        // If the content hasn't changed, don't write to the file. This prevents irrelevant watcher events.
-
-        match self.doc.get_at(&file_map, file_path, heads) {
-            Ok(Some((Value::Scalar(Cow::Owned(ScalarValue::Bytes(bytes))), _))) => Ok(bytes),
-            Ok(Some((Value::Scalar(Cow::Borrowed(ScalarValue::Bytes(bytes))), _))) => {
-                // TODO: Potentially memory-heavy operation. Figure out how to deal with Cows. Moo.
-                Ok(bytes.clone())
-            }
-            _ => {
-                bail!("Failed to provide contents of binary file at {file_path}");
-            }
-        }
     }
 
     // This function is used to integrate text that was changed while the daemon was offline.

--- a/crates/teamtype/src/document.rs
+++ b/crates/teamtype/src/document.rs
@@ -135,14 +135,14 @@ impl Document {
     }
 
     #[must_use]
-    pub fn generate_sync_message(
+    pub(crate) fn generate_sync_message(
         &mut self,
         peer_state: &mut AutomergeSyncState,
     ) -> Option<AutomergeSyncMessage> {
         self.doc.sync().generate_sync_message(peer_state)
     }
 
-    pub fn apply_delta_to_doc(
+    pub(crate) fn apply_delta_to_doc(
         &mut self,
         delta: &TextDelta,
         file_path: &RelativePath,
@@ -206,7 +206,7 @@ impl Document {
 
     // This function is used to integrate text that was changed while the daemon was offline.
     // We need to calculate the patches compared to the current CRDT content, and apply them.
-    pub fn update_text(
+    pub(crate) fn update_text(
         &mut self,
         desired_text: &str,
         file_path: &RelativePath,

--- a/crates/teamtype/src/editor.rs
+++ b/crates/teamtype/src/editor.rs
@@ -86,7 +86,7 @@ fn is_user_readable_only(socket_path: &Path) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn strip_current_dir(path: &Path) -> PathBuf {
+pub fn strip_current_dir(path: &Path) -> PathBuf {
     let Ok(cwd) = env::current_dir() else {
         return path.to_path_buf();
     };

--- a/crates/teamtype/src/editor_connection.rs
+++ b/crates/teamtype/src/editor_connection.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use tracing::debug;
 
 use crate::{
-    config::AppConfig,
+    config::Config,
     editor_protocol::{
         EditorProtocolMessageError, EditorProtocolMessageFromEditor, EditorProtocolMessageToEditor,
     },
@@ -25,7 +25,7 @@ use crate::{
 pub struct EditorConnection {
     id: String,
     // TODO: Feels duplicated here?
-    app_config: AppConfig,
+    config: Config,
     /// There's one [`OTServer`] per open buffer.
     ot_servers: HashMap<RelativePath, OTServer>,
     /// The name other people see.
@@ -33,11 +33,11 @@ pub struct EditorConnection {
 }
 
 impl EditorConnection {
-    pub fn new(id: String, app_config: AppConfig) -> Self {
+    pub fn new(id: String, config: Config) -> Self {
         Self {
             id,
-            username: app_config.username.clone(),
-            app_config,
+            username: config.username.clone(),
+            config,
             ot_servers: HashMap::new(),
         }
     }
@@ -60,7 +60,7 @@ impl EditorConnection {
                     debug!("Applying incoming CRDT patch for {file_path}");
                     let rev_text_delta_for_editor = ot_server.apply_crdt_change(delta).expect("Failed to apply delta originating from another component to OT Server. Probably the delta is invalid.");
 
-                    let uri = AbsolutePath::from_parts(&self.app_config.base_dir, file_path)
+                    let uri = AbsolutePath::from_parts(&self.config.base_dir, file_path)
                         .expect("Should be able to construct absolute URI")
                         .to_file_uri();
 
@@ -78,10 +78,9 @@ impl EditorConnection {
                 cursor_id,
                 cursor_state,
             } => {
-                let uri =
-                    AbsolutePath::from_parts(&self.app_config.base_dir, &cursor_state.file_path)
-                        .expect("Should be able to construct absolute URI")
-                        .to_file_uri();
+                let uri = AbsolutePath::from_parts(&self.config.base_dir, &cursor_state.file_path)
+                    .expect("Should be able to construct absolute URI")
+                    .to_file_uri();
 
                 vec![EditorProtocolMessageToEditor::Cursor {
                     userid: cursor_id.clone(),
@@ -119,21 +118,21 @@ impl EditorConnection {
                 let uri = FileUri::try_from(uri.clone()).map_err(anyhow_err_to_protocol_err)?;
                 let absolute_path = uri.to_absolute_path();
                 let relative_path =
-                    RelativePath::try_from_absolute(&self.app_config.base_dir, &absolute_path)
+                    RelativePath::try_from_absolute(&self.config.base_dir, &absolute_path)
                         .map_err(anyhow_err_to_protocol_err)?;
 
                 debug!("Got an 'open' message for {relative_path}");
-                if !sandbox::exists(&self.app_config.base_dir, &absolute_path)
+                if !sandbox::exists(&self.config.base_dir, &absolute_path)
                     .map_err(anyhow_err_to_protocol_err)?
                 {
                     // Creating nonexisting files allows us to traverse this file for whether it's
                     // ignored, which is needed to even be allowed to open it.
-                    sandbox::write_file(&self.app_config.base_dir, &absolute_path, b"")
+                    sandbox::write_file(&self.config.base_dir, &absolute_path, b"")
                         .map_err(anyhow_err_to_protocol_err)?;
                 }
 
                 // We only want to process these messages for files that are not ignored.
-                if sandbox::ignored(&self.app_config, &absolute_path)
+                if sandbox::ignored(&self.config, &absolute_path)
                     .expect("Could not check ignore status of opened file")
                 {
                     return Err(EditorProtocolMessageError {
@@ -158,7 +157,7 @@ impl EditorConnection {
                 let uri = FileUri::try_from(uri.clone()).map_err(anyhow_err_to_protocol_err)?;
                 let absolute_path = uri.to_absolute_path();
                 let relative_path =
-                    RelativePath::try_from_absolute(&self.app_config.base_dir, &absolute_path)
+                    RelativePath::try_from_absolute(&self.config.base_dir, &absolute_path)
                         .map_err(anyhow_err_to_protocol_err)?;
 
                 debug!("Got a 'close' message for {relative_path}");
@@ -184,7 +183,7 @@ impl EditorConnection {
                 let uri = FileUri::try_from(uri.clone()).map_err(anyhow_err_to_protocol_err)?;
                 let absolute_path = uri.to_absolute_path();
                 let relative_path =
-                    RelativePath::try_from_absolute(&self.app_config.base_dir, &absolute_path)
+                    RelativePath::try_from_absolute(&self.config.base_dir, &absolute_path)
                         .map_err(anyhow_err_to_protocol_err)?;
 
                 if self.ot_servers.get_mut(&relative_path).is_none() {
@@ -219,7 +218,7 @@ impl EditorConnection {
                     });
                 };
 
-                let uri = AbsolutePath::from_parts(&self.app_config.base_dir, &relative_path)
+                let uri = AbsolutePath::from_parts(&self.config.base_dir, &relative_path)
                     .expect("Should be able to construct absolute URI")
                     .to_file_uri();
 
@@ -244,7 +243,7 @@ impl EditorConnection {
                 let uri = FileUri::try_from(uri.clone()).map_err(anyhow_err_to_protocol_err)?;
                 let absolute_path = uri.to_absolute_path();
                 let relative_path =
-                    RelativePath::try_from_absolute(&self.app_config.base_dir, &absolute_path)
+                    RelativePath::try_from_absolute(&self.config.base_dir, &absolute_path)
                         .map_err(anyhow_err_to_protocol_err)?;
 
                 Ok((
@@ -277,12 +276,12 @@ mod tests {
     fn opening_file_in_wrong_dir_fails() {
         let dir = tempdir().expect("Failed to create temp directory");
 
-        let app_config = AppConfig {
+        let config = Config {
             base_dir: dir.path().to_path_buf(),
             ..Default::default()
         };
 
-        let mut editor_connection = EditorConnection::new("1".to_string(), app_config);
+        let mut editor_connection = EditorConnection::new("1".to_string(), config);
 
         let result =
             editor_connection.message_from_editor(&EditorProtocolMessageFromEditor::Open {
@@ -299,12 +298,12 @@ mod tests {
         let file = dir.path().join("file");
         fs::write(&file, "hello").expect("Failed to write file");
 
-        let app_config = AppConfig {
+        let config = Config {
             base_dir: dir.path().to_path_buf(),
             ..Default::default()
         };
 
-        let mut editor_connection = EditorConnection::new("1".to_string(), app_config);
+        let mut editor_connection = EditorConnection::new("1".to_string(), config);
 
         // Editor opens the file.
         let result =

--- a/crates/teamtype/src/jsonrpc_forwarder.rs
+++ b/crates/teamtype/src/jsonrpc_forwarder.rs
@@ -28,11 +28,9 @@ use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio_util::bytes::{Buf, BytesMut};
 use tokio_util::codec::{Decoder, Encoder, FramedRead, FramedWrite, LinesCodec};
 
+use super::config::CONFIG_DIR;
+use super::config::DEFAULT_SOCKET_NAME;
 use super::editor::strip_current_dir;
-
-// TODO: Put these defaults to a module accessible by config.rs as well.
-pub const DEFAULT_SOCKET_NAME: &str = "socket";
-pub const CONFIG_DIR: &str = ".teamtype";
 
 #[async_trait]
 pub trait JSONRPCForwarder<

--- a/crates/teamtype/src/lib.rs
+++ b/crates/teamtype/src/lib.rs
@@ -12,6 +12,7 @@ pub mod config;
 pub mod daemon;
 pub mod logging;
 pub mod sandbox;
+pub mod setup;
 pub mod traits;
 pub mod types;
 

--- a/crates/teamtype/src/lib.rs
+++ b/crates/teamtype/src/lib.rs
@@ -6,22 +6,30 @@
 
 #![doc = include_str!("../README.md")]
 
+// Public modules, either used by CLI or exported via crate or bindings
 pub mod config;
 pub mod daemon;
-pub mod document;
-pub mod editor;
-pub mod editor_connection;
-pub mod editor_protocol;
 pub mod jsonrpc_forwarder;
 pub mod logging;
-pub mod ot;
-pub mod path;
-pub mod peer;
 pub mod sandbox;
 pub mod traits;
 pub mod types;
-pub mod watcher;
-pub mod wormhole;
 
+// Used by e2e test crate, but not officially public
+#[doc(hidden)]
+pub mod document;
+#[doc(hidden)]
+pub mod editor_protocol;
+
+// Used by unit tests and hence compiled in a different crate context, but not public
 #[cfg(test)]
 pub(crate) mod testing;
+
+// Private modules
+mod editor;
+mod editor_connection;
+mod ot;
+mod path;
+mod peer;
+mod watcher;
+mod wormhole;

--- a/crates/teamtype/src/lib.rs
+++ b/crates/teamtype/src/lib.rs
@@ -7,9 +7,9 @@
 #![doc = include_str!("../README.md")]
 
 // Public modules, either used by CLI or exported via crate or bindings
+pub mod client;
 pub mod config;
 pub mod daemon;
-pub mod jsonrpc_forwarder;
 pub mod logging;
 pub mod sandbox;
 pub mod traits;
@@ -28,6 +28,7 @@ pub(crate) mod testing;
 // Private modules
 mod editor;
 mod editor_connection;
+mod jsonrpc_forwarder;
 mod ot;
 mod path;
 mod peer;

--- a/crates/teamtype/src/main.rs
+++ b/crates/teamtype/src/main.rs
@@ -17,16 +17,15 @@ use teamtype::setup::setup_teamtype_directory;
 use teamtype::types::UserInterface;
 use tokio::signal;
 
-use self::cli::{Cli, Commands};
-
 mod cli;
 mod cli_config;
 mod cli_ui;
 
-use cli_config::parse_directory_config;
-use cli_config::parse_join_config;
-use cli_config::parse_share_config;
-use cli_ui::ConsoleInteractions;
+use self::cli::{Cli, Commands};
+use self::cli_config::parse_directory_config;
+use self::cli_config::parse_join_config;
+use self::cli_config::parse_share_config;
+use self::cli_ui::ConsoleInteractions;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/teamtype/src/main.rs
+++ b/crates/teamtype/src/main.rs
@@ -17,9 +17,7 @@ use teamtype::config::{self, AppConfig};
 use teamtype::daemon::run_daemon;
 use teamtype::logging;
 use teamtype::setup::setup_teamtype_directory;
-use teamtype::setup::setup_temporary_directory;
 use teamtype::types::UserInterface;
-use tempfile::TempDir;
 use tokio::signal;
 
 use self::cli::{Cli, Commands, ShareJoinFlags};
@@ -48,9 +46,14 @@ async fn main() -> Result<()> {
 
     let ui = &UserInterface::new(ConsoleInteractions { quiet: cli.quiet });
 
-    let temporary_directory = get_temporary_directory(&cli)?;
-    let directory = get_directory(temporary_directory.as_ref(), &cli)?;
-    setup_teamtype_directory(&directory, temporary_directory.as_ref(), ui)
+    // Determine if the CLI flags request proceeding with a temporary directory, some user
+    // specified directory, or fallback to just the current directory.
+    let directory = parse_directory_config(&cli)?;
+
+    // Now that we know what the base directory is going to be, either validate our access to it and
+    // an existing config therein or setup a new config. In the event this step creates a temporary
+    // directory we need to hang onto the handle as long as we're running.
+    let (base_dir, _tempdir) = setup_teamtype_directory(directory.as_deref(), ui)
         .context("Failed to find .teamtype/ directory")?;
 
     // TODO: If the result of this joined future handles were to go out of scope and hence be
@@ -59,13 +62,13 @@ async fn main() -> Result<()> {
     // with the daemon module and merits refactoring so the long running socket and network
     // listeners properly listen to the mpsc channel or receive and process a cancellation token.
     let _handle = match cli.command {
-        Commands::Client => return run_client(directory.clone()).await,
+        Commands::Client => return run_client(base_dir).await,
         Commands::Join { .. } => {
-            let join_config = parse_join_config(cli.command, directory.clone(), ui).await?;
+            let join_config = parse_join_config(cli.command, base_dir, ui).await?;
             run_daemon(join_config, false, ui).await
         }
         Commands::Share { init, .. } => {
-            let share_config = parse_share_config(cli.command, directory.clone(), ui);
+            let share_config = parse_share_config(cli.command, base_dir, ui);
             run_daemon(share_config, init, ui).await
         }
     }?;
@@ -77,7 +80,7 @@ async fn main() -> Result<()> {
 
 async fn parse_join_config(
     command: Commands,
-    directory: PathBuf,
+    base_dir: PathBuf,
     ui: &UserInterface,
 ) -> Result<AppConfig> {
     if let Commands::Join {
@@ -96,7 +99,7 @@ async fn parse_join_config(
     } = command
     {
         let app_config_cli = AppConfig {
-            base_dir: directory,
+            base_dir,
             peer: join_code.map(config::Peer::JoinCode),
             emit_join_code: false,
             emit_secret_address: false,
@@ -118,7 +121,7 @@ async fn parse_join_config(
     }
 }
 
-fn parse_share_config(command: Commands, directory: PathBuf, ui: &UserInterface) -> AppConfig {
+fn parse_share_config(command: Commands, base_dir: PathBuf, ui: &UserInterface) -> AppConfig {
     if let Commands::Share {
         no_join_code,
         shared_flags:
@@ -136,7 +139,7 @@ fn parse_share_config(command: Commands, directory: PathBuf, ui: &UserInterface)
     } = command
     {
         let app_config_cli = AppConfig {
-            base_dir: directory,
+            base_dir,
             peer: None,
             emit_join_code: !no_join_code,
             emit_secret_address: show_secret_address,
@@ -154,6 +157,37 @@ fn parse_share_config(command: Commands, directory: PathBuf, ui: &UserInterface)
     } else {
         unreachable!("Only Share commands beget Share configs.")
     }
+}
+
+fn parse_directory_config(cli: &Cli) -> Result<Option<PathBuf>> {
+    match cli.command {
+        Commands::Share {
+            shared_flags:
+                ShareJoinFlags {
+                    temporary_directory,
+                    ..
+                },
+            ..
+        }
+        | Commands::Join {
+            shared_flags:
+                ShareJoinFlags {
+                    temporary_directory,
+                    ..
+                },
+            ..
+        } => {
+            if temporary_directory {
+                return Ok(None);
+            }
+        }
+        Commands::Client => {}
+    }
+    let directory = match cli.directory {
+        Some(ref directory) => directory,
+        None => &current_dir().context("Could not access current directory")?,
+    };
+    Ok(Some(directory.clone()))
 }
 
 async fn trap_shutdown(ui: &UserInterface) {
@@ -182,49 +216,4 @@ async fn trap_shutdown(ui: &UserInterface) {
             ui.inform("Got SIGTERM, shutting down");
         }
     }
-}
-
-fn get_temporary_directory(cli: &Cli) -> Result<Option<TempDir>> {
-    match cli.command {
-        Commands::Share {
-            shared_flags:
-                ShareJoinFlags {
-                    temporary_directory,
-                    ..
-                },
-            ..
-        }
-        | Commands::Join {
-            shared_flags:
-                ShareJoinFlags {
-                    temporary_directory,
-                    ..
-                },
-            ..
-        } => {
-            if temporary_directory {
-                Ok(Some(setup_temporary_directory()?))
-            } else {
-                Ok(None)
-            }
-        }
-        Commands::Client => Ok(None),
-    }
-}
-
-fn get_directory(temporary_directory: Option<&TempDir>, cli: &Cli) -> Result<PathBuf> {
-    let directory = match temporary_directory {
-        Some(temporary_directory) => &temporary_directory.path().to_path_buf(),
-        None => match cli.directory {
-            Some(ref directory) => directory,
-            None => &current_dir().context("Could not access current directory")?,
-        },
-    };
-    let directory = directory.canonicalize().with_context(|| {
-        format!(
-            "Could not compute the absolute, canonical form of the path of directory {}",
-            directory.display(),
-        )
-    })?;
-    Ok(directory)
 }

--- a/crates/teamtype/src/main.rs
+++ b/crates/teamtype/src/main.rs
@@ -5,26 +5,27 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::env::current_dir;
 use std::panic;
-use std::path::PathBuf;
 use std::process::exit;
 
 use anyhow::{Context, Result};
 use clap::{CommandFactory as _, FromArgMatches as _};
 use teamtype::client::run_client;
-use teamtype::config::{self, AppConfig};
 use teamtype::daemon::run_daemon;
 use teamtype::logging;
 use teamtype::setup::setup_teamtype_directory;
 use teamtype::types::UserInterface;
 use tokio::signal;
 
-use self::cli::{Cli, Commands, ShareJoinFlags};
+use self::cli::{Cli, Commands};
 
 mod cli;
+mod cli_config;
 mod cli_ui;
 
+use cli_config::parse_directory_config;
+use cli_config::parse_join_config;
+use cli_config::parse_share_config;
 use cli_ui::ConsoleInteractions;
 
 #[tokio::main]
@@ -76,118 +77,6 @@ async fn main() -> Result<()> {
     trap_shutdown(ui).await;
 
     Ok(())
-}
-
-async fn parse_join_config(
-    command: Commands,
-    base_dir: PathBuf,
-    ui: &UserInterface,
-) -> Result<AppConfig> {
-    if let Commands::Join {
-        join_code,
-        shared_flags:
-            ShareJoinFlags {
-                magic_wormhole_relay,
-                iroh_relay,
-                iroh_dns_domain,
-                iroh_pkarr_relay,
-                sync_vcs,
-                username,
-                ..
-            },
-        ..
-    } = command
-    {
-        let app_config_cli = AppConfig {
-            base_dir,
-            peer: join_code.map(config::Peer::JoinCode),
-            emit_join_code: false,
-            emit_secret_address: false,
-            magic_wormhole_relay,
-            iroh_relay,
-            iroh_dns_domain,
-            iroh_pkarr_relay,
-            sync_vcs,
-            username,
-        };
-        let mut app_config = AppConfig::from_config_file_and_cli(app_config_cli, ui);
-        app_config = app_config
-            .resolve_peer(ui)
-            .await
-            .context("Failed to resolve peer")?;
-        Ok(app_config)
-    } else {
-        unreachable!("Only Join commands beget Join configs.")
-    }
-}
-
-fn parse_share_config(command: Commands, base_dir: PathBuf, ui: &UserInterface) -> AppConfig {
-    if let Commands::Share {
-        no_join_code,
-        shared_flags:
-            ShareJoinFlags {
-                magic_wormhole_relay,
-                iroh_relay,
-                iroh_dns_domain,
-                iroh_pkarr_relay,
-                sync_vcs,
-                username,
-                ..
-            },
-        show_secret_address,
-        ..
-    } = command
-    {
-        let app_config_cli = AppConfig {
-            base_dir,
-            peer: None,
-            emit_join_code: !no_join_code,
-            emit_secret_address: show_secret_address,
-            magic_wormhole_relay,
-            iroh_relay,
-            iroh_dns_domain,
-            iroh_pkarr_relay,
-            sync_vcs,
-            username,
-        };
-        let mut app_config = AppConfig::from_config_file_and_cli(app_config_cli, ui);
-        // Because of the "share" subcommand, explicitly don't connect anywhere.
-        app_config.peer = None;
-        app_config
-    } else {
-        unreachable!("Only Share commands beget Share configs.")
-    }
-}
-
-fn parse_directory_config(cli: &Cli) -> Result<Option<PathBuf>> {
-    match cli.command {
-        Commands::Share {
-            shared_flags:
-                ShareJoinFlags {
-                    temporary_directory,
-                    ..
-                },
-            ..
-        }
-        | Commands::Join {
-            shared_flags:
-                ShareJoinFlags {
-                    temporary_directory,
-                    ..
-                },
-            ..
-        } => {
-            if temporary_directory {
-                return Ok(None);
-            }
-        }
-        Commands::Client => {}
-    }
-    let directory = match cli.directory {
-        Some(ref directory) => directory,
-        None => &current_dir().context("Could not access current directory")?,
-    };
-    Ok(Some(directory.clone()))
 }
 
 async fn trap_shutdown(ui: &UserInterface) {

--- a/crates/teamtype/src/main.rs
+++ b/crates/teamtype/src/main.rs
@@ -5,9 +5,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use std::env::current_dir;
+use std::panic;
 use std::path::{Path, PathBuf};
 use std::process::exit;
-use std::{env, panic};
 
 use anyhow::bail;
 use anyhow::{Context, Result};
@@ -277,7 +278,7 @@ fn get_directory(temporary_directory: Option<&TempDir>, cli: &Cli) -> Result<Pat
         Some(temporary_directory) => &temporary_directory.path().to_path_buf(),
         None => match cli.directory {
             Some(ref directory) => directory,
-            None => &get_current_directory()?,
+            None => &current_dir().context("Could not access current directory")?,
         },
     };
     let directory = directory.canonicalize().with_context(|| {
@@ -317,8 +318,4 @@ fn setup_teamtype_directory(
         }
     }
     Ok(())
-}
-
-fn get_current_directory() -> Result<PathBuf> {
-    env::current_dir().context("Could not access current directory")
 }

--- a/crates/teamtype/src/main.rs
+++ b/crates/teamtype/src/main.rs
@@ -7,22 +7,19 @@
 
 use std::env::current_dir;
 use std::panic;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::exit;
 
-use anyhow::bail;
 use anyhow::{Context, Result};
 use clap::{CommandFactory as _, FromArgMatches as _};
-use docstr::docstr;
-use microxdg::XdgApp;
 use teamtype::client::run_client;
+use teamtype::config::{self, AppConfig};
 use teamtype::daemon::run_daemon;
+use teamtype::logging;
+use teamtype::setup::setup_teamtype_directory;
+use teamtype::setup::setup_temporary_directory;
 use teamtype::types::UserInterface;
-use teamtype::{
-    config::{self, AppConfig},
-    logging, sandbox,
-};
-use tempfile::{TempDir, tempdir_in};
+use tempfile::TempDir;
 use tokio::signal;
 
 use self::cli::{Cli, Commands, ShareJoinFlags};
@@ -31,13 +28,6 @@ mod cli;
 mod cli_ui;
 
 use cli_ui::ConsoleInteractions;
-
-fn has_teamtype_directory(dir: &Path) -> bool {
-    let teamtype_dir = dir.join(config::CONFIG_DIR);
-    // Using the sandbox method here is technically unnecessary,
-    // but we want to really run all path operations through the sandbox module.
-    sandbox::exists(dir, &teamtype_dir).expect("Failed to check") && teamtype_dir.is_dir()
-}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -213,36 +203,13 @@ fn get_temporary_directory(cli: &Cli) -> Result<Option<TempDir>> {
             ..
         } => {
             if temporary_directory {
-                let temporary_directory_parent_directory = &get_app_cache_dir()?;
-                Ok(Some(
-                    tempdir_in(temporary_directory_parent_directory).with_context(|| {
-                        format!(
-                            "Failed to create a temporary directory in the directory {}",
-                            temporary_directory_parent_directory.display()
-                        )
-                    })?,
-                ))
+                Ok(Some(setup_temporary_directory()?))
             } else {
                 Ok(None)
             }
         }
         Commands::Client => Ok(None),
     }
-}
-
-fn get_app_cache_dir() -> Result<PathBuf> {
-    let xdg = XdgApp::new("teamtype")?;
-    let app_cache_dir = xdg.app_cache()?;
-    let app_cache_dir_parent = app_cache_dir.parent().with_context(|| {
-        format!(
-            "Failed to get parent directory of the directory {}",
-            app_cache_dir.display()
-        )
-    })?;
-    // Using the sandbox method here is technically unnecessary,
-    // but we want to really run all path operations through the sandbox module.
-    sandbox::create_dir(app_cache_dir_parent, &app_cache_dir)?;
-    Ok(app_cache_dir)
 }
 
 fn get_directory(temporary_directory: Option<&TempDir>, cli: &Cli) -> Result<PathBuf> {
@@ -260,34 +227,4 @@ fn get_directory(temporary_directory: Option<&TempDir>, cli: &Cli) -> Result<Pat
         )
     })?;
     Ok(directory)
-}
-
-fn setup_teamtype_directory(
-    directory: &Path,
-    temporary_directory: Option<&TempDir>,
-    ui: &UserInterface,
-) -> Result<()> {
-    if !has_teamtype_directory(directory) {
-        let teamtype_dir = directory.join(config::CONFIG_DIR);
-        let directory_is_temporary_directory = temporary_directory.is_some();
-        if directory_is_temporary_directory {
-            ui.log(&format!(
-                "'{}' is the temporary directory that is used as a Teamtype directory.",
-                directory.display()
-            ));
-            sandbox::create_dir(directory, &teamtype_dir)?;
-        } else if ui.confirm(&docstr!(format!
-            /// '{}' hasn't been used as a Teamtype directory before.
-            ///
-            /// Do you want to enable live collaboration here? (This will create a {}/ directory.)
-            directory.display(),
-            config::CONFIG_DIR
-        ))? {
-            sandbox::create_dir(directory, &teamtype_dir)?;
-            ui.log("Created! Resuming launch.");
-        } else {
-            bail!("Aborting launch. Teamtype needs a .teamtype/ directory to function");
-        }
-    }
-    Ok(())
 }

--- a/crates/teamtype/src/main.rs
+++ b/crates/teamtype/src/main.rs
@@ -16,10 +16,10 @@ use clap::{CommandFactory as _, FromArgMatches as _};
 use docstr::docstr;
 use microxdg::XdgApp;
 use teamtype::client::run_client;
+use teamtype::daemon::run_daemon;
 use teamtype::types::UserInterface;
 use teamtype::{
     config::{self, AppConfig},
-    daemon::Daemon,
     logging, sandbox,
 };
 use tempfile::{TempDir, tempdir_in};
@@ -83,34 +83,6 @@ async fn main() -> Result<()> {
     trap_shutdown(ui).await;
 
     Ok(())
-}
-
-async fn run_daemon(app_config: AppConfig, init_doc: bool, ui: &UserInterface) -> Result<Daemon> {
-    let persist = !config::has_git_remote(&app_config.base_dir);
-    if !persist {
-        // TODO: drop .teamtype/doc here? Would that be rude?
-        ui.log(
-            "Detected a Git remote: Assuming a pair-programming use-case and starting a new history."
-        );
-    }
-
-    config::ensure_teamtype_is_ignored(&app_config.base_dir)?;
-
-    if app_config.sync_vcs && config::has_local_user_config(&app_config.base_dir).is_ok_and(|v| v) {
-        ui.warn(docstr!(
-            /// You have a local user configuration in your .git/config.
-            /// In --sync-vcs mode, this file will also be synchronized between peers.
-            /// If your version "wins", all peers will have the same Git identity.
-            /// As a workaround, you could use `git commit --author`.
-        ));
-    }
-
-    // Setup a new daemon from the derived config. Immediately join the handle because that's what
-    // actually starts the local socket and any configured network connections. Return the result
-    // so the calling context can determine when to terminate.
-    Daemon::new(app_config, init_doc, persist, ui)
-        .await
-        .context("Failed to launch the daemon")
 }
 
 async fn parse_join_config(

--- a/crates/teamtype/src/main.rs
+++ b/crates/teamtype/src/main.rs
@@ -14,7 +14,7 @@ use anyhow::{Context, Result};
 use clap::{CommandFactory as _, FromArgMatches as _};
 use docstr::docstr;
 use microxdg::XdgApp;
-use teamtype::jsonrpc_forwarder::{JSONRPCForwarder, UnixJSONRPCForwarder};
+use teamtype::client::run_client;
 use teamtype::types::UserInterface;
 use teamtype::{
     config::{self, AppConfig},
@@ -191,14 +191,6 @@ fn parse_share_config(command: Commands, directory: PathBuf, ui: &UserInterface)
     } else {
         unreachable!("Only Share commands beget Share configs.")
     }
-}
-
-async fn run_client(directory: PathBuf) -> Result<()> {
-    let jsonrpc_forwarder = UnixJSONRPCForwarder {};
-    jsonrpc_forwarder
-        .connection(&directory)
-        .await
-        .context("JSON-RPC forwarder failed")
 }
 
 async fn trap_shutdown(ui: &UserInterface) {

--- a/crates/teamtype/src/peer.rs
+++ b/crates/teamtype/src/peer.rs
@@ -29,7 +29,7 @@ use tracing::debug;
 use url::Url;
 
 use self::sync::{Connection, PeerMessage, SyncActor};
-use crate::config::AppConfig;
+use crate::config::Config;
 use crate::daemon::DocumentActorHandle;
 use crate::types::UserInterface;
 
@@ -73,14 +73,14 @@ pub struct ConnectionManager {
 
 impl ConnectionManager {
     pub async fn new(
-        app_config: &AppConfig,
+        config: &Config,
         document_handle: DocumentActorHandle,
         base_dir: &Path,
         ui: &UserInterface,
     ) -> Result<Self> {
         let (message_tx, message_rx) = mpsc::channel(1);
 
-        let (endpoint, my_passphrase) = Self::build_endpoint(app_config, base_dir).await?;
+        let (endpoint, my_passphrase) = Self::build_endpoint(config, base_dir).await?;
 
         let encoded_passphrase = data_encoding::HEXLOWER.encode(&my_passphrase.to_bytes());
         let secret_address = format!("{}#{}", endpoint.id(), encoded_passphrase);
@@ -124,17 +124,14 @@ impl ConnectionManager {
         Ok(())
     }
 
-    async fn build_endpoint(
-        app_config: &AppConfig,
-        base_dir: &Path,
-    ) -> Result<(Endpoint, SecretKey)> {
+    async fn build_endpoint(config: &Config, base_dir: &Path) -> Result<(Endpoint, SecretKey)> {
         let (secret_key, my_passphrase) = Self::get_keypair(base_dir);
 
         let mut builder = Endpoint::builder(presets::N0)
             .secret_key(secret_key)
             .alpns(vec![ALPN.to_vec()]);
 
-        let relay_mode = match &app_config.iroh_relay {
+        let relay_mode = match &config.iroh_relay {
             Some(iroh_relay) => {
                 let relay_url = RelayUrl::from_str(iroh_relay)?;
                 let relay_map = RelayMap::from(relay_url);
@@ -144,7 +141,7 @@ impl ConnectionManager {
         };
         builder = builder.relay_mode(relay_mode);
 
-        let iroh_dns_lookup = app_config.iroh_dns_domain.as_ref().map_or_else(
+        let iroh_dns_lookup = config.iroh_dns_domain.as_ref().map_or_else(
             DnsAddressLookup::n0_dns,
             |iroh_dns_domain| {
                 let iroh_dns_domain_clone = iroh_dns_domain.clone();
@@ -153,7 +150,7 @@ impl ConnectionManager {
         );
         builder = builder.address_lookup(iroh_dns_lookup);
 
-        let iroh_pkarr_lookup = match &app_config.iroh_pkarr_relay {
+        let iroh_pkarr_lookup = match &config.iroh_pkarr_relay {
             Some(iroh_pkarr_relay) => {
                 let iroh_pkarr_relay_url = Url::parse(iroh_pkarr_relay)?;
                 PkarrPublisher::builder(iroh_pkarr_relay_url)

--- a/crates/teamtype/src/sandbox.rs
+++ b/crates/teamtype/src/sandbox.rs
@@ -20,7 +20,7 @@ use ignore::WalkBuilder;
 use ignore::overrides::OverrideBuilder;
 use path_clean::PathClean;
 
-use crate::config::AppConfig;
+use crate::config::Config;
 
 pub(crate) fn read_file(absolute_base_dir: &Path, absolute_file_path: &Path) -> Result<Vec<u8>> {
     let canonical_file_path =
@@ -105,13 +105,13 @@ pub fn exists(absolute_base_dir: &Path, absolute_file_path: &Path) -> Result<boo
     Ok(canonical_file_path.exists())
 }
 
-pub(crate) fn enumerate_non_ignored_files(app_config: &AppConfig) -> Vec<PathBuf> {
+pub(crate) fn enumerate_non_ignored_files(config: &Config) -> Vec<PathBuf> {
     let mut ignored_things = vec![".teamtype"];
-    if !app_config.sync_vcs {
+    if !config.sync_vcs {
         ignored_things.extend([".teamtype", ".git", ".bzr", ".hg", ".jj", ".pijul", ".svn"]);
     }
 
-    let walk = WalkBuilder::new(&app_config.base_dir)
+    let walk = WalkBuilder::new(&config.base_dir)
         .add_custom_ignore_filename(".teamtypeignore")
         .standard_filters(true)
         .hidden(false)
@@ -144,15 +144,15 @@ pub(crate) fn enumerate_non_ignored_files(app_config: &AppConfig) -> Vec<PathBuf
     // doesn't seem to allow for that - as soon as we positive-list something, everything else gets
     // ignored.
     // So do a second walk, and merge the results.
-    if app_config.sync_vcs {
-        let overrides = OverrideBuilder::new(app_config.base_dir.clone())
+    if config.sync_vcs {
+        let overrides = OverrideBuilder::new(config.base_dir.clone())
             .add(".jj/")
             .expect("Failed to add pattern to OverrideBuilder")
             .add(".jj/**")
             .expect("Failed to add pattern to OverrideBuilder")
             .build()
             .expect("Failed to build Overrides");
-        let walk = WalkBuilder::new(&app_config.base_dir)
+        let walk = WalkBuilder::new(&config.base_dir)
             .overrides(overrides)
             .build();
         let jj_files: Vec<PathBuf> = walk
@@ -175,11 +175,11 @@ pub(crate) fn enumerate_non_ignored_files(app_config: &AppConfig) -> Vec<PathBuf
 
 // TODO: Don't build the list of ignored files on every call.
 // TODO: Allow calling this for non-existing files.
-pub(crate) fn ignored(app_config: &AppConfig, absolute_file_path: &Path) -> Result<bool> {
+pub(crate) fn ignored(config: &Config, absolute_file_path: &Path) -> Result<bool> {
     let canonical_file_path =
-        check_inside_base_dir_and_canonicalize(&app_config.base_dir, absolute_file_path)?;
+        check_inside_base_dir_and_canonicalize(&config.base_dir, absolute_file_path)?;
 
-    Ok(!enumerate_non_ignored_files(app_config)
+    Ok(!enumerate_non_ignored_files(config)
         .into_iter()
         .map(|path_buf| absolute_and_canonicalized(&path_buf))
         .collect::<Result<Vec<_>>>()?
@@ -361,24 +361,24 @@ mod tests {
 
         fs::write(&teamtypeignore, b"a\n").expect("Failed to write .teamtypeignore");
 
-        let app_config = AppConfig {
+        let config = Config {
             base_dir: project_dir.clone(),
             ..Default::default()
         };
 
         assert!(
-            ignored(&app_config, &project_dir.join("a")).unwrap(),
+            ignored(&config, &project_dir.join("a")).unwrap(),
             "a should be ignored"
         );
         assert!(
-            !ignored(&app_config, &project_dir.join("dir/b")).unwrap(),
+            !ignored(&config, &project_dir.join("dir/b")).unwrap(),
             "b should be not ignored"
         );
 
         fs::write(&teamtypeignore, b"a\ndir\n").expect("Failed to write .teamtypeignore");
 
         assert!(
-            ignored(&app_config, &project_dir.join("dir/b")).unwrap(),
+            ignored(&config, &project_dir.join("dir/b")).unwrap(),
             "now b should be ignored"
         );
     }

--- a/crates/teamtype/src/sandbox.rs
+++ b/crates/teamtype/src/sandbox.rs
@@ -22,7 +22,7 @@ use path_clean::PathClean;
 
 use crate::config::AppConfig;
 
-pub fn read_file(absolute_base_dir: &Path, absolute_file_path: &Path) -> Result<Vec<u8>> {
+pub(crate) fn read_file(absolute_base_dir: &Path, absolute_file_path: &Path) -> Result<Vec<u8>> {
     let canonical_file_path =
         check_inside_base_dir_and_canonicalize(absolute_base_dir, absolute_file_path)?;
     let bytes = fs::read(canonical_file_path)?;
@@ -48,7 +48,7 @@ pub fn write_file(
     Ok(())
 }
 
-pub fn append_file(
+pub(crate) fn append_file(
     absolute_base_dir: &Path,
     absolute_file_path: &Path,
     content: &[u8],
@@ -92,7 +92,7 @@ pub fn create_dir(absolute_base_dir: &Path, absolute_dir_path: &Path) -> Result<
     Ok(())
 }
 
-pub fn create_dir_all(absolute_base_dir: &Path, absolute_dir_path: &Path) -> Result<()> {
+fn create_dir_all(absolute_base_dir: &Path, absolute_dir_path: &Path) -> Result<()> {
     let canonical_dir_path =
         check_inside_base_dir_and_canonicalize(absolute_base_dir, absolute_dir_path)?;
     fs::create_dir_all(canonical_dir_path)?;
@@ -105,7 +105,7 @@ pub fn exists(absolute_base_dir: &Path, absolute_file_path: &Path) -> Result<boo
     Ok(canonical_file_path.exists())
 }
 
-pub fn enumerate_non_ignored_files(app_config: &AppConfig) -> Vec<PathBuf> {
+pub(crate) fn enumerate_non_ignored_files(app_config: &AppConfig) -> Vec<PathBuf> {
     let mut ignored_things = vec![".teamtype"];
     if !app_config.sync_vcs {
         ignored_things.extend([".teamtype", ".git", ".bzr", ".hg", ".jj", ".pijul", ".svn"]);
@@ -175,7 +175,7 @@ pub fn enumerate_non_ignored_files(app_config: &AppConfig) -> Vec<PathBuf> {
 
 // TODO: Don't build the list of ignored files on every call.
 // TODO: Allow calling this for non-existing files.
-pub fn ignored(app_config: &AppConfig, absolute_file_path: &Path) -> Result<bool> {
+pub(crate) fn ignored(app_config: &AppConfig, absolute_file_path: &Path) -> Result<bool> {
     let canonical_file_path =
         check_inside_base_dir_and_canonicalize(&app_config.base_dir, absolute_file_path)?;
 

--- a/crates/teamtype/src/setup.rs
+++ b/crates/teamtype/src/setup.rs
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::path::{Path, PathBuf};
+
+use anyhow::bail;
+use anyhow::{Context, Result};
+use docstr::docstr;
+use microxdg::XdgApp;
+use tempfile::{TempDir, tempdir_in};
+
+use crate::config::{self};
+use crate::sandbox;
+use crate::types::UserInterface;
+
+pub fn setup_teamtype_directory(
+    directory: &Path,
+    temporary_directory: Option<&TempDir>,
+    ui: &UserInterface,
+) -> Result<()> {
+    if !has_teamtype_directory(directory) {
+        let teamtype_dir = directory.join(config::CONFIG_DIR);
+        let directory_is_temporary_directory = temporary_directory.is_some();
+        if directory_is_temporary_directory {
+            ui.log(&format!(
+                "'{}' is the temporary directory that is used as a Teamtype directory.",
+                directory.display()
+            ));
+            sandbox::create_dir(directory, &teamtype_dir)?;
+        } else if ui.confirm(&docstr!(format!
+            /// '{}' hasn't been used as a Teamtype directory before.
+            ///
+            /// Do you want to enable live collaboration here? (This will create a {}/ directory.)
+            directory.display(),
+            config::CONFIG_DIR
+        ))? {
+            sandbox::create_dir(directory, &teamtype_dir)?;
+            ui.log("Created! Resuming launch.");
+        } else {
+            bail!("Aborting launch. Teamtype needs a .teamtype/ directory to function");
+        }
+    }
+    Ok(())
+}
+
+fn has_teamtype_directory(dir: &Path) -> bool {
+    let teamtype_dir = dir.join(config::CONFIG_DIR);
+    // Using the sandbox method here is technically unnecessary,
+    // but we want to really run all path operations through the sandbox module.
+    sandbox::exists(dir, &teamtype_dir).expect("Failed to check") && teamtype_dir.is_dir()
+}
+
+pub fn setup_temporary_directory() -> Result<TempDir> {
+    let parent_dir = get_app_cache_dir()?;
+    tempdir_in(&parent_dir).with_context(|| {
+        format!(
+            "Failed to create a temporary directory in the directory {}",
+            parent_dir.display()
+        )
+    })
+}
+
+fn get_app_cache_dir() -> Result<PathBuf> {
+    let xdg = XdgApp::new("teamtype")?;
+    let app_cache_dir = xdg.app_cache()?;
+    let app_cache_dir_parent = app_cache_dir.parent().with_context(|| {
+        format!(
+            "Failed to get parent directory of the directory {}",
+            app_cache_dir.display()
+        )
+    })?;
+    // Using the sandbox method here is technically unnecessary,
+    // but we want to really run all path operations through the sandbox module.
+    sandbox::create_dir(app_cache_dir_parent, &app_cache_dir)?;
+    Ok(app_cache_dir)
+}

--- a/crates/teamtype/src/setup.rs
+++ b/crates/teamtype/src/setup.rs
@@ -15,33 +15,37 @@ use crate::sandbox;
 use crate::types::UserInterface;
 
 pub fn setup_teamtype_directory(
-    directory: &Path,
-    temporary_directory: Option<&TempDir>,
+    directory: Option<&Path>,
     ui: &UserInterface,
-) -> Result<()> {
-    if !has_teamtype_directory(directory) {
-        let teamtype_dir = directory.join(config::CONFIG_DIR);
-        let directory_is_temporary_directory = temporary_directory.is_some();
-        if directory_is_temporary_directory {
-            ui.log(&format!(
-                "'{}' is the temporary directory that is used as a Teamtype directory.",
-                directory.display()
-            ));
-            sandbox::create_dir(directory, &teamtype_dir)?;
-        } else if ui.confirm(&docstr!(format!
+) -> Result<(PathBuf, Option<TempDir>)> {
+    let (base_dir, temp_dir) = if let Some(directory) = directory.as_ref() {
+        let base_dir = directory.canonicalize().with_context(|| {
+            format!(
+                "Could not compute the absolute, canonical form of the path of directory {}",
+                directory.display(),
+            )
+        })?;
+        (base_dir, None)
+    } else {
+        let temp_dir = setup_temporary_directory()?;
+        (temp_dir.path().to_path_buf(), Some(temp_dir))
+    };
+    if !has_teamtype_directory(&base_dir) {
+        let teamtype_dir = base_dir.join(config::CONFIG_DIR);
+        if ui.confirm(&docstr!(format!
             /// '{}' hasn't been used as a Teamtype directory before.
             ///
             /// Do you want to enable live collaboration here? (This will create a {}/ directory.)
-            directory.display(),
+            base_dir.display(),
             config::CONFIG_DIR
         ))? {
-            sandbox::create_dir(directory, &teamtype_dir)?;
+            sandbox::create_dir(&base_dir, &teamtype_dir)?;
             ui.log("Created! Resuming launch.");
         } else {
             bail!("Aborting launch. Teamtype needs a .teamtype/ directory to function");
         }
     }
-    Ok(())
+    Ok((base_dir, temp_dir))
 }
 
 fn has_teamtype_directory(dir: &Path) -> bool {

--- a/crates/teamtype/src/types.rs
+++ b/crates/teamtype/src/types.rs
@@ -69,7 +69,7 @@ impl fmt::Display for TextDelta {
 }
 
 impl TextDelta {
-    pub fn apply_to(&self, text: &str) -> Result<String> {
+    pub(crate) fn apply_to(&self, text: &str) -> Result<String> {
         let chars: Vec<char> = text.chars().collect();
         let mut pos = 0;
         let mut result = String::new();
@@ -629,7 +629,7 @@ impl From<Vec<Chunk<'_>>> for TextDelta {
 }
 
 impl EditorTextDelta {
-    pub fn try_from_delta(delta: TextDelta, content: &str) -> Result<Self> {
+    pub(crate) fn try_from_delta(delta: TextDelta, content: &str) -> Result<Self> {
         let mut editor_ops = vec![];
         let mut position = 0;
         for op in delta {

--- a/crates/teamtype/src/types.rs
+++ b/crates/teamtype/src/types.rs
@@ -189,7 +189,7 @@ impl FileTextDelta {
     }
 }
 
-pub type CursorId = String;
+pub(crate) type CursorId = String;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
 pub struct CursorState {

--- a/crates/teamtype/src/types.rs
+++ b/crates/teamtype/src/types.rs
@@ -5,8 +5,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use std::borrow::Cow;
+use std::fmt::{self, Display, Formatter};
 use std::sync::Arc;
-use std::{fmt, vec};
+use std::vec::{IntoIter, Vec};
 
 use anyhow::bail;
 use anyhow::{Context, Error, Result};
@@ -27,7 +28,7 @@ use crate::traits::Interactions;
 pub struct InteractionsHandle(Arc<dyn Interactions>);
 
 impl fmt::Debug for InteractionsHandle {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str(self.0.type_name())
     }
 }
@@ -61,8 +62,8 @@ impl UserInterface {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TextDelta(pub Vec<TextOp>);
 
-impl fmt::Display for TextDelta {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Display for TextDelta {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let op_strings: Vec<String> = self.0.iter().map(|op| format!("{op}")).collect();
         write!(f, "[{}]", op_strings.join(", "))
     }
@@ -102,7 +103,7 @@ impl TextDelta {
 }
 
 impl IntoIterator for TextDelta {
-    type IntoIter = vec::IntoIter<Self::Item>;
+    type IntoIter = IntoIter<Self::Item>;
     type Item = TextOp;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -117,8 +118,8 @@ pub enum TextOp {
     Delete(usize),
 }
 
-impl fmt::Display for TextOp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Display for TextOp {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             Self::Retain(n) => write!(f, "{n}"),
             Self::Insert(str) => write!(f, "\"{str}\""),
@@ -131,7 +132,7 @@ impl fmt::Display for TextOp {
 pub struct EditorTextDelta(pub Vec<EditorTextOp>);
 
 impl IntoIterator for EditorTextDelta {
-    type IntoIter = vec::IntoIter<Self::Item>;
+    type IntoIter = IntoIter<Self::Item>;
     type Item = EditorTextOp;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/crates/teamtype/src/watcher.rs
+++ b/crates/teamtype/src/watcher.rs
@@ -22,7 +22,7 @@ use tokio::{
 };
 use tracing::debug;
 
-use crate::{config::AppConfig, sandbox};
+use crate::{config::Config, sandbox};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct WatcherEvent {
@@ -46,14 +46,14 @@ struct PendingEvent {
 #[must_use]
 pub struct Watcher {
     _inner: RecommendedWatcher,
-    app_config: AppConfig,
+    config: Config,
     notify_receiver: Receiver<NotifyResult<Event>>,
     event_tx: Sender<WatcherEvent>,
     pending_events: HashMap<PathBuf, PendingEvent>,
 }
 
 impl Watcher {
-    pub fn spawn(app_config: AppConfig) -> Receiver<WatcherEvent> {
+    pub fn spawn(config: Config) -> Receiver<WatcherEvent> {
         let (event_tx, event_rx) = mpsc::channel(1);
 
         let (tx, rx) = mpsc::channel(1);
@@ -67,13 +67,13 @@ impl Watcher {
         .expect("Could not construct watcher");
 
         watcher
-            .watch(&app_config.base_dir, RecursiveMode::Recursive)
+            .watch(&config.base_dir, RecursiveMode::Recursive)
             .expect("Failed to watch directory");
 
         let mut watcher = Self {
             // Keep the watcher, so that it's not dropped.
             _inner: watcher,
-            app_config,
+            config,
             notify_receiver: rx,
             event_tx,
             pending_events: HashMap::default(),
@@ -129,7 +129,7 @@ impl Watcher {
                         )) => {
                             assert_eq!(event.paths.len(), 1);
                             let file_path = event.paths[0].clone();
-                            match sandbox::exists(&self.app_config.base_dir, &file_path) {
+                            match sandbox::exists(&self.config.base_dir, &file_path) {
                                 Ok(path_exists) => {
                                     if path_exists {
                                         self.maybe_created(&file_path);
@@ -194,7 +194,7 @@ impl Watcher {
     }
 
     fn maybe_created(&mut self, file_path: &Path) {
-        match sandbox::ignored(&self.app_config, file_path) {
+        match sandbox::ignored(&self.config, file_path) {
             Ok(is_ignored) => {
                 if is_ignored {
                     debug!("Ignoring creation of '{}'", file_path.display());
@@ -221,7 +221,7 @@ impl Watcher {
     }
 
     fn maybe_modified(&mut self, file_path: &Path) {
-        match sandbox::ignored(&self.app_config, file_path) {
+        match sandbox::ignored(&self.config, file_path) {
             Ok(is_ignored) => {
                 if is_ignored {
                     debug!("Ignoring modification of '{}'", file_path.display());
@@ -280,7 +280,7 @@ mod tests {
 
     use super::*;
 
-    fn create_temp_dir_and_app_config() -> (TempDir, PathBuf, AppConfig) {
+    fn create_temp_dir_and_config() -> (TempDir, PathBuf, Config) {
         let dir = tempdir().expect("Failed to create temp directory");
 
         // We canonicalize the path here, because on macOS, TempDir gives us paths in /var/, which
@@ -288,22 +288,22 @@ mod tests {
         // If we wouldn't canonicalize, the watcher would ignore basically all events.
         let dir_path = dir.path().canonicalize().unwrap();
 
-        let app_config = AppConfig {
+        let config = Config {
             base_dir: dir_path.clone(),
             ..Default::default()
         };
 
-        (dir, dir_path, app_config)
+        (dir, dir_path, config)
     }
 
     #[tokio::test]
     async fn create() {
-        let (_dir, dir_path, app_config) = create_temp_dir_and_app_config();
+        let (_dir, dir_path, config) = create_temp_dir_and_config();
 
         let mut file = dir_path.clone();
         file.push("file");
 
-        let mut watcher = Watcher::spawn(app_config);
+        let mut watcher = Watcher::spawn(config);
         sandbox::write_file(&dir_path, &file, b"hi").unwrap();
 
         assert_eq!(
@@ -318,13 +318,13 @@ mod tests {
     #[tokio::test]
     #[cfg(target_os = "linux")]
     async fn change() {
-        let (_dir, dir_path, app_config) = create_temp_dir_and_app_config();
+        let (_dir, dir_path, config) = create_temp_dir_and_config();
 
         let mut file = dir_path.clone();
         file.push("file");
         sandbox::write_file(&dir_path, &file, b"hi").unwrap();
 
-        let mut watcher = Watcher::spawn(app_config);
+        let mut watcher = Watcher::spawn(config);
 
         sandbox::write_file(&dir_path, &file, b"yo").unwrap();
 
@@ -339,13 +339,13 @@ mod tests {
 
     #[tokio::test]
     async fn remove() {
-        let (_dir, dir_path, app_config) = create_temp_dir_and_app_config();
+        let (_dir, dir_path, config) = create_temp_dir_and_config();
 
         let mut file = dir_path.clone();
         file.push("file");
         sandbox::write_file(&dir_path, &file, b"hi").unwrap();
 
-        let mut watcher = Watcher::spawn(app_config);
+        let mut watcher = Watcher::spawn(config);
 
         sandbox::remove_file(&dir_path, &file).unwrap();
 
@@ -360,7 +360,7 @@ mod tests {
 
     #[tokio::test]
     async fn rename() {
-        let (_dir, dir_path, app_config) = create_temp_dir_and_app_config();
+        let (_dir, dir_path, config) = create_temp_dir_and_config();
 
         let mut file = dir_path.clone();
         file.push("file");
@@ -368,7 +368,7 @@ mod tests {
         file_new.push("file2");
         sandbox::write_file(&dir_path, &file, b"hi").unwrap();
 
-        let mut watcher = Watcher::spawn(app_config);
+        let mut watcher = Watcher::spawn(config);
 
         sandbox::rename_file(&dir_path, &file, &file_new).unwrap();
 
@@ -391,14 +391,14 @@ mod tests {
 
     #[tokio::test]
     async fn ignore() {
-        let (_dir, dir_path, app_config) = create_temp_dir_and_app_config();
+        let (_dir, dir_path, config) = create_temp_dir_and_config();
 
         let mut gitignore = dir_path.clone();
         gitignore.push(".ignore");
         sandbox::write_file(&dir_path, &gitignore, b"file").unwrap();
 
         sleep(Duration::from_millis(100)).await;
-        let mut watcher = Watcher::spawn(app_config);
+        let mut watcher = Watcher::spawn(config);
 
         let mut file = dir_path.clone();
         file.push("file");
@@ -419,13 +419,13 @@ mod tests {
 
     #[tokio::test]
     async fn remove_then_create() {
-        let (_dir, dir_path, app_config) = create_temp_dir_and_app_config();
+        let (_dir, dir_path, config) = create_temp_dir_and_config();
 
         let mut file = dir_path.clone();
         file.push("file");
         sandbox::write_file(&dir_path, &file, b"hi").unwrap();
 
-        let mut watcher = Watcher::spawn(app_config);
+        let mut watcher = Watcher::spawn(config);
 
         sandbox::remove_file(&dir_path, &file).unwrap();
         sandbox::write_file(&dir_path, &file, b"i'm back").unwrap();


### PR DESCRIPTION
This is a logical follow up and stacked on ~~#551, #541, #603, #611, and #601~~.

The split between binary and library crates and the exposed public API surface was clearly not considered while this was developed. Not knocking the work—it's just time for a refactor so multiple contexts can be supported. As of this posting I'd say I'm about half way there removing public exports that clearly belong, then we can start considering what the ergonomics are for the bits that are left.

<img width="1284" height="3132" alt="image" src="https://github.com/user-attachments/assets/f85d0ffd-6061-4227-b149-969415518493" />

( BEFORE → AFTER )

In normal circumstances taking away published APIs would be considered breaking, but since I don't think we have any consumers yet and the publication was somewhat accidental I don't think we must identify it as such *per se*.

**Self-review checklist**

- [-] I described the changes of the PR in the [CHANGELOG](https://github.com/teamtype/teamtype/blob/main/CHANGELOG.md).
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
