### PR TITLE
Deconflate logging vs. user interactions, remove all ui from the lib crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,6 +849,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,8 +1201,23 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d3bd1363713fdb3b9a1fbc70fd24a63314a362c4701551127828494827e8fb8"
 dependencies = [
- "litrs",
+ "litrs 0.5.1",
 ]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs 1.0.0",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e-tests"
@@ -1513,6 +1555,15 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio-io",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -2182,6 +2233,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
+dependencies = [
+ "bitflags",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2574,6 +2639,12 @@ name = "litrs"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4cf394bcd88ba72eb3b2862e21ef6458b0e1586654e213b0176e667bb9d19e"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -4157,6 +4228,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4447,6 +4539,7 @@ dependencies = [
  "futures 0.3.32",
  "git2 0.21.0",
  "ignore",
+ "inquire",
  "iroh",
  "magic-wormhole",
  "microxdg",
@@ -4918,6 +5011,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/e2e-tests/tests/fuzzer.rs
+++ b/crates/e2e-tests/tests/fuzzer.rs
@@ -20,7 +20,7 @@ use teamtype::traits::Interactions;
 use teamtype::types::UserInterface;
 use tempfile::{TempDir, tempdir};
 use tokio::time::{Duration, sleep, timeout};
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 async fn perform_random_edits(actor: &mut (impl Actor + ?Sized)) {
     for _ in 1..500 {
@@ -48,7 +48,12 @@ fn initialize_directory() -> (TempDir, PathBuf, PathBuf) {
 
 struct FuzzerInteractions {}
 
-impl Interactions for FuzzerInteractions {}
+impl Interactions for FuzzerInteractions {
+    fn confirm(&self, question: &str) -> Result<bool> {
+        debug!("Fuzzer asked for a confirmation '{question}', answering with 'false'");
+        Ok(false)
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/e2e-tests/tests/fuzzer.rs
+++ b/crates/e2e-tests/tests/fuzzer.rs
@@ -20,7 +20,7 @@ use teamtype::traits::Interactions;
 use teamtype::types::UserInterface;
 use tempfile::{TempDir, tempdir};
 use tokio::time::{Duration, sleep, timeout};
-use tracing::{debug, error, info};
+use tracing::{debug, info, warn};
 
 async fn perform_random_edits(actor: &mut (impl Actor + ?Sized)) {
     for _ in 1..500 {
@@ -52,6 +52,14 @@ impl Interactions for FuzzerInteractions {
     fn confirm(&self, question: &str) -> Result<bool> {
         debug!("Fuzzer asked for a confirmation '{question}', answering with 'false'");
         Ok(false)
+    }
+
+    fn inform(&self, message: &str) {
+        info!(message);
+    }
+
+    fn warn(&self, message: &str) {
+        warn!(message);
     }
 }
 
@@ -139,7 +147,7 @@ async fn main() -> Result<()> {
     })
     .await
     .unwrap_or_else(|_| {
-        error!("Timeout while waiting for all contents to be equal");
+        ui.warn("Timeout while waiting for all contents to be equal");
     });
 
     // Get all contents.

--- a/crates/e2e-tests/tests/fuzzer.rs
+++ b/crates/e2e-tests/tests/fuzzer.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<()> {
 
     logging::initialize()?;
 
-    let _ui = &UserInterface::new(FuzzerInteractions {});
+    let ui = &UserInterface::new(FuzzerInteractions {});
 
     // Set up files in shared directories. The directories will get cleaned up automatically when
     // the handle goes out of scope. We don't *use* the handle but we do need to keep it in scope.
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
     // Set up the actors.
     let mut app_config = AppConfig::default();
     app_config.base_dir = dir1;
-    let daemon = Daemon::new(app_config, true, false).await?;
+    let daemon = Daemon::new(app_config, true, false, ui).await?;
 
     // Wait until iroh's DNS discovery (hopefully) works.
     sleep(Duration::from_millis(1000)).await;
@@ -80,7 +80,7 @@ async fn main() -> Result<()> {
     let mut app_config2 = AppConfig::default();
     app_config2.base_dir = dir2;
     app_config2.peer = Some(config::Peer::SecretAddress(daemon.address.clone()));
-    let peer = Daemon::new(app_config2, false, false).await?;
+    let peer = Daemon::new(app_config2, false, false, ui).await?;
 
     // Wait until file2 appears.
     while !file2.exists() {

--- a/crates/e2e-tests/tests/fuzzer.rs
+++ b/crates/e2e-tests/tests/fuzzer.rs
@@ -54,6 +54,10 @@ impl Interactions for FuzzerInteractions {
         Ok(false)
     }
 
+    fn log(&self, message: &str) {
+        debug!(message);
+    }
+
     fn inform(&self, message: &str) {
         info!(message);
     }
@@ -112,7 +116,7 @@ async fn main() -> Result<()> {
     actors.insert("peer".to_string(), Box::new(peer));
     actors.insert("nvim2".to_string(), Box::new(nvim2));
 
-    info!("Performing edits");
+    ui.log("Performing edits");
 
     let handles = actors
         .iter_mut()
@@ -121,7 +125,7 @@ async fn main() -> Result<()> {
 
     let mut contents: HashMap<String, String> = HashMap::new();
 
-    info!("Waiting for all contents to be equal");
+    ui.log("Waiting for all contents to be equal");
 
     timeout(Duration::from_secs(5 * 60), async {
         loop {

--- a/crates/e2e-tests/tests/fuzzer.rs
+++ b/crates/e2e-tests/tests/fuzzer.rs
@@ -16,6 +16,8 @@ use teamtype::config::{self, AppConfig};
 use teamtype::daemon::{Daemon, TEST_FILE_PATH};
 use teamtype::logging;
 use teamtype::sandbox;
+use teamtype::traits::Interactions;
+use teamtype::types::UserInterface;
 use tempfile::{TempDir, tempdir};
 use tokio::time::{Duration, sleep, timeout};
 use tracing::{error, info};
@@ -44,6 +46,10 @@ fn initialize_directory() -> (TempDir, PathBuf, PathBuf) {
     (dir, dir_path.to_path_buf(), file)
 }
 
+struct FuzzerInteractions {}
+
+impl Interactions for FuzzerInteractions {}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let default_panic = std::panic::take_hook();
@@ -53,6 +59,8 @@ async fn main() -> Result<()> {
     }));
 
     logging::initialize()?;
+
+    let _ui = &UserInterface::new(FuzzerInteractions {});
 
     // Set up files in shared directories. The directories will get cleaned up automatically when
     // the handle goes out of scope. We don't *use* the handle but we do need to keep it in scope.

--- a/crates/teamtype/Cargo.toml
+++ b/crates/teamtype/Cargo.toml
@@ -38,7 +38,7 @@ crate-type = ["rlib", "cdylib"]
 [features]
 # This is unfortunate, but users of the crate as a library should use `default-features = false`.
 default = ["cli"]
-cli = ["dep:clap", "tokio/signal", "tokio/rt-multi-thread"]
+cli = ["dep:clap", "dep:inquire", "tokio/signal", "tokio/rt-multi-thread"]
 
 [build-dependencies]
 anyhow.workspace = true
@@ -90,6 +90,10 @@ features = ["as_ref", "deref", "display"]
 [dependencies.git2]
 version = "0.21"
 default-features = false
+
+[dependencies.inquire]
+version = "0.9"
+optional = true
 
 [dependencies.notify]
 version = "8"

--- a/crates/teamtype/src/cli_ui.rs
+++ b/crates/teamtype/src/cli_ui.rs
@@ -4,6 +4,7 @@
 
 use anyhow::{Context, Result};
 use inquire::Confirm;
+use nu_ansi_term::Color;
 use teamtype::traits::Interactions;
 use tracing::debug;
 
@@ -17,5 +18,16 @@ impl Interactions for ConsoleInteractions {
             .with_default(false)
             .prompt()
             .context("Failed to read answer to y/n prompt")
+    }
+
+    fn inform(&self, message: &str) {
+        debug!("UI inform event: {message}");
+        println!("{message}");
+    }
+
+    fn warn(&self, message: &str) {
+        let yellow = Color::Yellow;
+        debug!("UI warn event: {message}");
+        eprintln!("{}", yellow.paint(message));
     }
 }

--- a/crates/teamtype/src/cli_ui.rs
+++ b/crates/teamtype/src/cli_ui.rs
@@ -2,9 +2,20 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use anyhow::{Context, Result};
+use inquire::Confirm;
 use teamtype::traits::Interactions;
+use tracing::debug;
 
 #[derive(Clone)]
 pub struct ConsoleInteractions {}
 
-impl Interactions for ConsoleInteractions {}
+impl Interactions for ConsoleInteractions {
+    fn confirm(&self, question: &str) -> Result<bool> {
+        debug!("UI confirm event: {question}");
+        Confirm::new(question)
+            .with_default(false)
+            .prompt()
+            .context("Failed to read answer to y/n prompt")
+    }
+}

--- a/crates/teamtype/src/cli_ui.rs
+++ b/crates/teamtype/src/cli_ui.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{Context, Result};
 use inquire::Confirm;
-use nu_ansi_term::Color;
+use nu_ansi_term::{Color, Style};
 use teamtype::traits::Interactions;
 use tracing::debug;
 
@@ -18,6 +18,12 @@ impl Interactions for ConsoleInteractions {
             .with_default(false)
             .prompt()
             .context("Failed to read answer to y/n prompt")
+    }
+
+    fn log(&self, message: &str) {
+        let dimmed = Style::new().dimmed();
+        debug!("UI log event: {message}");
+        println!("{}", dimmed.paint(message));
     }
 
     fn inform(&self, message: &str) {

--- a/crates/teamtype/src/cli_ui.rs
+++ b/crates/teamtype/src/cli_ui.rs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use teamtype::traits::Interactions;
+
+#[derive(Clone)]
+pub struct ConsoleInteractions {}
+
+impl Interactions for ConsoleInteractions {}

--- a/crates/teamtype/src/config.rs
+++ b/crates/teamtype/src/config.rs
@@ -17,6 +17,7 @@ use ini::{Ini, Properties};
 use tracing::info;
 
 use crate::sandbox;
+use crate::types::UserInterface;
 use crate::wormhole::get_secret_address_from_wormhole;
 
 pub const DOC_FILE: &str = "doc";
@@ -61,7 +62,7 @@ impl AppConfig {
     // - For strings, the CLI app config attribute has precedence.
     // - For booleans, if a value deviates from the default, it "wins".
     // - The `base_dir` will be taken from the CLI app config.
-    pub fn from_config_file_and_cli(app_config_cli: Self) -> Self {
+    pub fn from_config_file_and_cli(app_config_cli: Self, ui: &UserInterface) -> Self {
         let base_dir = app_config_cli.base_dir;
         let config_file = base_dir.join(CONFIG_DIR).join(CONFIG_FILE);
         let empty_properties_section = Properties::new();
@@ -76,7 +77,7 @@ impl AppConfig {
 
         // we do the computation of username before initializing the struct, because we need to
         // reference base_dir, which gets moved during the initialization of the struct
-        let username = get_username(app_config_cli.username, &base_dir, general_section);
+        let username = get_username(app_config_cli.username, &base_dir, general_section, ui);
         Self {
             // TODO: extract all the other fields to its own struct, s.t. we don't have to work
             // around the fact that base_dir won't ever be in the config file.
@@ -132,20 +133,21 @@ impl AppConfig {
     /// If we have a join code, try to use that and overwrite the config file.
     /// If we don't have a join code, try to use the configured peer.
     /// Otherwise, fail.
-    pub async fn resolve_peer(self) -> Result<Self> {
+    pub async fn resolve_peer(self, ui: &UserInterface) -> Result<Self> {
         let mut result = self.clone();
         let peer = match self.peer {
             Some(Peer::JoinCode(ref join_code)) => {
-                let secret_address =
-                    get_secret_address_from_wormhole(join_code, self.magic_wormhole_relay.clone())
-                        .await
-                        .context(
-                            "Failed to retrieve secret address, was this join code already used?",
-                        )?;
+                let secret_address = get_secret_address_from_wormhole(
+                    join_code,
+                    self.magic_wormhole_relay.clone(),
+                    ui,
+                )
+                .await
+                .context("Failed to retrieve secret address, was this join code already used?")?;
                 info!(
                     "Derived peer from join code. Storing in config (overwriting previous config)."
                 );
-                store_peer_in_config(&self.base_dir, &self.config_file(), &secret_address)?;
+                store_peer_in_config(&self.base_dir, &self.config_file(), &secret_address, ui)?;
                 Peer::SecretAddress(secret_address)
             }
             Some(Peer::SecretAddress(secret_address)) => {
@@ -166,7 +168,12 @@ impl AppConfig {
     }
 }
 
-pub fn store_peer_in_config(directory: &Path, config_file: &Path, peer: &str) -> Result<()> {
+pub fn store_peer_in_config(
+    directory: &Path,
+    config_file: &Path,
+    peer: &str,
+    _ui: &UserInterface,
+) -> Result<()> {
     info!("Storing peer's address in .teamtype/config.");
 
     let content = format!("peer={peer}\n");
@@ -212,20 +219,24 @@ fn get_username(
     app_config_cli_username: Option<String>,
     base_dir: &Path,
     general_section: &Properties,
+    ui: &UserInterface,
 ) -> String {
     app_config_cli_username
-        .map(get_username_from_cli)
-        .or_else(|| get_username_from_config_file(general_section))
-        .or_else(|| get_username_from_git(base_dir))
-        .unwrap_or_else(get_username_from_fallback_value)
+        .map(|u| get_username_from_cli(u, ui))
+        .or_else(|| get_username_from_config_file(general_section, ui))
+        .or_else(|| get_username_from_git(base_dir, ui))
+        .unwrap_or_else(|| get_username_from_fallback_value(ui))
 }
 
-fn get_username_from_cli(username: String) -> String {
+fn get_username_from_cli(username: String, _ui: &UserInterface) -> String {
     info!("Using the username '{username}' to display next to the cursors other people see.");
     username
 }
 
-fn get_username_from_config_file(general_section: &Properties) -> Option<String> {
+fn get_username_from_config_file(
+    general_section: &Properties,
+    _ui: &UserInterface,
+) -> Option<String> {
     general_section
         .get("username")
         .map(ToString::to_string)
@@ -235,7 +246,7 @@ fn get_username_from_config_file(general_section: &Properties) -> Option<String>
         })
 }
 
-fn get_username_from_git(base_dir: &Path) -> Option<String> {
+fn get_username_from_git(base_dir: &Path, _ui: &UserInterface) -> Option<String> {
     let username = get_git_username(base_dir);
     if let Some(ref username) = username {
         info!(
@@ -251,7 +262,7 @@ fn get_username_from_git(base_dir: &Path) -> Option<String> {
     username
 }
 
-fn get_username_from_fallback_value() -> String {
+fn get_username_from_fallback_value(_ui: &UserInterface) -> String {
     let username = USERNAME_FALLBACK.to_string();
     info!(
         "{}",

--- a/crates/teamtype/src/config.rs
+++ b/crates/teamtype/src/config.rs
@@ -14,7 +14,6 @@ use anyhow::{Context, Result};
 use docstr::docstr;
 use git2::{Config as GitConfig, ConfigLevel, Error as GitError, Repository};
 use ini::{Ini, Properties};
-use tracing::info;
 
 use crate::sandbox;
 use crate::types::UserInterface;
@@ -144,14 +143,14 @@ impl AppConfig {
                 )
                 .await
                 .context("Failed to retrieve secret address, was this join code already used?")?;
-                info!(
-                    "Derived peer from join code. Storing in config (overwriting previous config)."
+                ui.log(
+                    "Derived peer from join code. Storing in config (overwriting previous config).",
                 );
                 store_peer_in_config(&self.base_dir, &self.config_file(), &secret_address, ui)?;
                 Peer::SecretAddress(secret_address)
             }
             Some(Peer::SecretAddress(secret_address)) => {
-                info!("Using peer from config file.");
+                ui.log("Using peer from config file.");
                 Peer::SecretAddress(secret_address)
             }
             None => {
@@ -172,9 +171,9 @@ pub fn store_peer_in_config(
     directory: &Path,
     config_file: &Path,
     peer: &str,
-    _ui: &UserInterface,
+    ui: &UserInterface,
 ) -> Result<()> {
-    info!("Storing peer's address in .teamtype/config.");
+    ui.log("Storing peer's address in .teamtype/config.");
 
     let content = format!("peer={peer}\n");
     sandbox::write_file(directory, config_file, content.as_bytes())
@@ -228,50 +227,48 @@ fn get_username(
         .unwrap_or_else(|| get_username_from_fallback_value(ui))
 }
 
-fn get_username_from_cli(username: String, _ui: &UserInterface) -> String {
-    info!("Using the username '{username}' to display next to the cursors other people see.");
+fn get_username_from_cli(username: String, ui: &UserInterface) -> String {
+    ui.log(&format!(
+        "Using the username '{username}' to display next to the cursors other people see."
+    ));
     username
 }
 
 fn get_username_from_config_file(
     general_section: &Properties,
-    _ui: &UserInterface,
+    ui: &UserInterface,
 ) -> Option<String> {
     general_section
         .get("username")
         .map(ToString::to_string)
         .map(|username| {
-            info!("Using the username '{username}' from `.teamtype/config` as username, to display next to the cursors other people see.");
+            ui.log(&format!(
+                "Using the username '{username}' from `.teamtype/config` as username, to display next to the cursors other people see."
+            ));
             username
         })
 }
 
-fn get_username_from_git(base_dir: &Path, _ui: &UserInterface) -> Option<String> {
+fn get_username_from_git(base_dir: &Path, ui: &UserInterface) -> Option<String> {
     let username = get_git_username(base_dir);
     if let Some(ref username) = username {
-        info!(
-            "{}",
-            &docstr!(format!
-                /// Using the Git username '{username}' as username, to display next to the cursors other people see.
-                /// Teamtype uses the Git username as username by default.
-                /// You can set the configuration value `username` in your `.teamtype/config` to override this username.
-                /// You can also use the flag `--username` when using the `share`/`join` subcommands.
-            )
-        );
+        ui.log(&docstr!(format!
+            /// Using the Git username '{username}' as username, to display next to the cursors other people see.
+            /// Teamtype uses the Git username as username by default.
+            /// You can set the configuration value `username` in your `.teamtype/config` to override this username.
+            /// You can also use the flag `--username` when using the `share`/`join` subcommands.
+        ));
     }
     username
 }
 
-fn get_username_from_fallback_value(_ui: &UserInterface) -> String {
+fn get_username_from_fallback_value(ui: &UserInterface) -> String {
     let username = USERNAME_FALLBACK.to_string();
-    info!(
-        "{}",
-        &docstr!(format!
-            /// Using the fallback value for username '{username}' as username, to display next to the cursors other people see.
-            /// You can set the configuration value `username` in your `.teamtype/config` to override this username.
-            /// You can also use the flag `--username` when using the `share`/`join` subcommands.
-        )
-    );
+    ui.log(&docstr!(format!
+        /// Using the fallback value for username '{username}' as username, to display next to the cursors other people see.
+        /// You can set the configuration value `username` in your `.teamtype/config` to override this username.
+        /// You can also use the flag `--username` when using the `share`/`join` subcommands.
+    ));
     username
 }
 

--- a/crates/teamtype/src/daemon.rs
+++ b/crates/teamtype/src/daemon.rs
@@ -41,6 +41,7 @@ use crate::editor_protocol::{
 use crate::path::{AbsolutePath, RelativePath};
 use crate::peer;
 use crate::sandbox;
+use crate::types::UserInterface;
 use crate::types::{
     ComponentMessage, CursorId, CursorState, EphemeralMessage, FileTextDelta, PatchEffect,
     TextDelta,
@@ -116,15 +117,18 @@ pub struct DocumentActor {
     /// The Document is the main I/O managed resource of this actor.
     crdt_doc: Document,
     app_config: AppConfig,
+    _ui: UserInterface,
     save_fully: bool,
 }
 
 impl DocumentActor {
+    #[expect(clippy::too_many_arguments)]
     fn new(
         doc_message_rx: mpsc::Receiver<DocMessage>,
         doc_changed_ping_tx: DocChangedSender,
         ephemeral_message_tx: EphemeralMessageSender,
         app_config: AppConfig,
+        ui: &UserInterface,
         init: bool,
         is_host: bool,
         persist: bool,
@@ -143,9 +147,9 @@ impl DocumentActor {
             );
             let bytes = sandbox::read_file(&app_config.base_dir, &persistence_file)
                 .unwrap_or_else(|_| panic!("Could not read file '{}'", persistence_file.display()));
-            Document::load(&bytes)
+            Document::load(&bytes, ui)
         } else {
-            Document::default()
+            Document::new(ui)
         };
         debug!("Loading CRDT document completed.");
 
@@ -156,6 +160,7 @@ impl DocumentActor {
             editor_connections: HashMap::default(),
             ephemeral_states: HashMap::default(),
             app_config,
+            _ui: ui.clone(),
             crdt_doc,
             save_fully: true,
         };
@@ -869,7 +874,13 @@ pub struct DocumentActorHandle {
 }
 
 impl DocumentActorHandle {
-    pub fn new(app_config: &AppConfig, init: bool, is_host: bool, persist: bool) -> Self {
+    pub fn new(
+        app_config: &AppConfig,
+        ui: &UserInterface,
+        init: bool,
+        is_host: bool,
+        persist: bool,
+    ) -> Self {
         // The document task will receive messages on this channel.
         let (doc_message_tx, doc_message_rx) = mpsc::channel(1);
 
@@ -886,6 +897,7 @@ impl DocumentActorHandle {
             doc_changed_ping_tx.clone(),
             ephemeral_message_tx.clone(),
             app_config.clone(),
+            ui,
             init,
             is_host,
             persist,
@@ -954,10 +966,15 @@ pub struct Daemon {
 
 impl Daemon {
     // Launch the daemon. Optionally, connect to given peer.
-    pub async fn new(app_config: AppConfig, init: bool, persist: bool) -> Result<Self> {
+    pub async fn new(
+        app_config: AppConfig,
+        init: bool,
+        persist: bool,
+        ui: &UserInterface,
+    ) -> Result<Self> {
         let is_host = app_config.is_host();
 
-        let document_handle = DocumentActorHandle::new(&app_config, init, is_host, persist);
+        let document_handle = DocumentActorHandle::new(&app_config, ui, init, is_host, persist);
 
         let base_dir = &app_config.base_dir;
 
@@ -965,7 +982,7 @@ impl Daemon {
         let socket_path = base_dir
             .join(config::CONFIG_DIR)
             .join(config::DEFAULT_SOCKET_NAME);
-        editor::spawn_socket_listener(&socket_path, document_handle.clone())?;
+        editor::spawn_socket_listener(&socket_path, document_handle.clone(), ui)?;
 
         // Start file watcher.
         spawn_file_watcher(&app_config, document_handle.clone());
@@ -977,7 +994,7 @@ impl Daemon {
 
         // Start connection manager.
         let connection_manager =
-            peer::ConnectionManager::new(&app_config, document_handle.clone(), base_dir)
+            peer::ConnectionManager::new(&app_config, document_handle.clone(), base_dir, ui)
                 .await
                 .expect("Failed to start connection manager");
         let address = connection_manager.secret_address();
@@ -994,7 +1011,7 @@ impl Daemon {
             );
         }
         if app_config.emit_join_code {
-            put_secret_address_into_wormhole(address, app_config.magic_wormhole_relay.clone())
+            put_secret_address_into_wormhole(address, app_config.magic_wormhole_relay.clone(), ui)
                 .await;
         }
         if let Some(config::Peer::SecretAddress(ref secret_address)) = app_config.peer {
@@ -1098,7 +1115,7 @@ fn spawn_persister(document_handle: DocumentActorHandle) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    //use crate::types::factories::*;
+    use crate::testing::TestInteractions;
 
     mod document_actor {
         use tempfile::{TempDir, tempdir};
@@ -1120,6 +1137,8 @@ mod tests {
                 let (ephemeral_message_tx, _ephemeral_message_rx) =
                     broadcast::channel::<EphemeralMessage>(100);
 
+                let ui = &UserInterface::new(TestInteractions {});
+
                 Self::new(
                     doc_message_rx,
                     doc_changed_ping_tx,
@@ -1128,6 +1147,7 @@ mod tests {
                         base_dir: directory.path().to_path_buf(),
                         ..Default::default()
                     },
+                    ui,
                     true,
                     true,
                     false,

--- a/crates/teamtype/src/daemon.rs
+++ b/crates/teamtype/src/daemon.rs
@@ -28,7 +28,7 @@ use tokio::{
     time::sleep,
     time::{Duration, Instant},
 };
-use tracing::{debug, info};
+use tracing::debug;
 
 use crate::config::{self, AppConfig};
 use crate::document::{self, Document};
@@ -253,7 +253,7 @@ impl DocumentActor {
                         }
                         PatchEffect::FileRemoval(file_path) => {
                             if self.owns(&file_path) {
-                                info!("Removing file {file_path}.");
+                                self.ui.inform(&format!("Removing file {file_path}."));
 
                                 sandbox::remove_file(
                                     &self.app_config.base_dir,
@@ -297,9 +297,9 @@ impl DocumentActor {
                                     // modifications to the editors, and these contents should be
                                     // consistent. So we don't need to do anything.
                                 } else {
-                                    info!(
+                                    self.ui.inform(&format!(
                                         "Peer deleted {file_path}, but you have it open in an editor. Bringing back an empty version."
-                                    );
+                                    ));
                                     self.crdt_doc.update_text("", &file_path);
                                 }
                             }
@@ -612,7 +612,7 @@ impl DocumentActor {
                 debug!("Failed to read {abs_path} to check for equal content before writing.");
             }
         } else {
-            info!("Creating file {file_path}.");
+            self.ui.inform(&format!("Creating file {file_path}."));
         }
 
         sandbox::write_file(&self.app_config.base_dir, &abs_path, bytes)
@@ -1142,6 +1142,7 @@ mod tests {
                 let (ephemeral_message_tx, _ephemeral_message_rx) =
                     broadcast::channel::<EphemeralMessage>(100);
 
+                //
                 let ui = &UserInterface::new(TestInteractions {});
 
                 Self::new(

--- a/crates/teamtype/src/daemon.rs
+++ b/crates/teamtype/src/daemon.rs
@@ -28,7 +28,7 @@ use tokio::{
     time::sleep,
     time::{Duration, Instant},
 };
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info};
 
 use crate::config::{self, AppConfig};
 use crate::document::{self, Document};
@@ -117,7 +117,7 @@ pub struct DocumentActor {
     /// The Document is the main I/O managed resource of this actor.
     crdt_doc: Document,
     app_config: AppConfig,
-    _ui: UserInterface,
+    ui: UserInterface,
     save_fully: bool,
 }
 
@@ -160,7 +160,7 @@ impl DocumentActor {
             editor_connections: HashMap::default(),
             ephemeral_states: HashMap::default(),
             app_config,
-            _ui: ui.clone(),
+            ui: ui.clone(),
             crdt_doc,
             save_fully: true,
         };
@@ -260,7 +260,8 @@ impl DocumentActor {
                                     &self.absolute_path_for_file_path(&file_path),
                                 )
                                 .unwrap_or_else(|err| {
-                                    warn!("Failed to remove file {file_path}: {err}");
+                                    self.ui
+                                        .warn(&format!("Failed to remove file {file_path}: {err}"));
                                 });
                             } else {
                                 // At least one editor has the file open. We want to allow it to
@@ -321,7 +322,8 @@ impl DocumentActor {
                 }
 
                 if response_tx.send(peer_state).is_err() {
-                    warn!("Failed to send peer state in response to ReceiveSyncMessage.");
+                    self.ui
+                        .warn("Failed to send peer state in response to ReceiveSyncMessage.");
                 }
             }
             DocMessage::GenerateSyncMessage {
@@ -331,7 +333,7 @@ impl DocumentActor {
                 let message = self.crdt_doc.generate_sync_message(&mut peer_state);
 
                 if response_tx.send((peer_state, message)).is_err() {
-                    warn!(
+                    self.ui.warn(
                         "Failed to send peer state and sync message in response to GenerateSyncMessage."
                     );
                 }
@@ -416,7 +418,8 @@ impl DocumentActor {
                 let result = self.react_to_message_from_editor(editor_id, &payload).await;
                 match result {
                     Err(error) => {
-                        error!("Error for JSON-RPC request: {:?}", error);
+                        self.ui
+                            .warn(&format!("Error for JSON-RPC request: {error:?}"));
                         self.send_to_editor_client(
                             &editor_id,
                             OutgoingMessage::Response(JSONRPCResponse::RequestError {
@@ -481,10 +484,10 @@ impl DocumentActor {
         let new_content = match sandbox::read_file(&self.app_config.base_dir, &file_path) {
             Ok(content) => content,
             Err(e) => {
-                warn!(
+                self.ui.warn(&format!(
                     "The file watcher noticed a file creation/change for {relative_file_path}, \
                     but we couldn't read it: {e} (probably it was deleted after the change?)"
-                );
+                ));
                 return;
             }
         };
@@ -555,7 +558,9 @@ impl DocumentActor {
             .expect("Could not get editor handle");
 
         connection.1.send(message).await.unwrap_or_else(|err| {
-            error!("Failed to send message to editor: {err} Removing editor.");
+            self.ui.warn(&format!(
+                "Failed to send message to editor: {err} Removing editor."
+            ));
             self.editor_connections.remove(editor_id);
         });
     }
@@ -578,9 +583,9 @@ impl DocumentActor {
             let bytes = text.as_bytes();
             self.ensure_file_has_bytes(file_path, bytes);
         } else {
-            warn!(
+            self.ui.warn(&format!(
                 "Failed to get content of file '{file_path}' when writing to disk. Key should have existed?"
-            );
+            ));
         }
     }
 
@@ -639,7 +644,10 @@ impl DocumentActor {
                     }
                 }
                 Err(e) => {
-                    warn!("Failed to read file '{}': {e}", file_path.display());
+                    self.ui.warn(&format!(
+                        "Failed to read file '{}': {e}",
+                        file_path.display()
+                    ));
                 }
             }
         }
@@ -652,9 +660,9 @@ impl DocumentActor {
                 )
                 && self.owns(&relative_file_path)
             {
-                warn!(
+                self.ui.warn(&format!(
                         "File {relative_file_path} exists in the CRDT, but not on disk. Deleting from CRDT."
-                    );
+                    ));
                 self.remove_file(&relative_file_path);
             }
         }
@@ -1000,15 +1008,12 @@ impl Daemon {
         let address = connection_manager.secret_address();
 
         if app_config.emit_secret_address {
-            info!(
-                "{}",
-                &docstr!(format!
-                    /// Others can connect by putting the following secret address in their .teamtype/config:
-                    ///
-                    ///     peer={address}
-                    ///
-                )
-            );
+            ui.inform(&docstr!(format!
+                /// Others can connect by putting the following secret address in their .teamtype/config:
+                ///
+                ///     peer={address}
+                ///
+            ));
         }
         if app_config.emit_join_code {
             put_secret_address_into_wormhole(address, app_config.magic_wormhole_relay.clone(), ui)

--- a/crates/teamtype/src/daemon.rs
+++ b/crates/teamtype/src/daemon.rs
@@ -242,7 +242,7 @@ impl DocumentActor {
 
                 let patches = self.apply_sync_message_to_doc(message, &mut peer_state);
 
-                let patch_effects = PatchEffect::from_crdt_patches(&patches);
+                let patch_effects = PatchEffect::from_crdt_patches(&patches, &self.ui);
 
                 let mut file_deltas = vec![];
 

--- a/crates/teamtype/src/daemon.rs
+++ b/crates/teamtype/src/daemon.rs
@@ -989,15 +989,12 @@ impl Daemon {
         let address = connection_manager.secret_address();
 
         if app_config.emit_secret_address {
-            info!(
-                "{}",
-                &docstr!(format!
-                    /// Others can connect by putting the following secret address in their .teamtype/config:
-                    ///
-                    ///     peer={address}
-                    ///
-                )
-            );
+            ui.inform(&docstr!(format!
+                /// Others can connect by putting the following secret address in their .teamtype/config:
+                ///
+                ///     peer={address}
+                ///
+            ));
         }
         if app_config.emit_join_code {
             put_secret_address_into_wormhole(address, app_config.magic_wormhole_relay.clone(), ui)

--- a/crates/teamtype/src/daemon.rs
+++ b/crates/teamtype/src/daemon.rs
@@ -41,6 +41,7 @@ use crate::editor_protocol::{
 use crate::path::{AbsolutePath, RelativePath};
 use crate::peer;
 use crate::sandbox;
+use crate::types::UserInterface;
 use crate::types::{
     ComponentMessage, CursorId, CursorState, EphemeralMessage, FileTextDelta, PatchEffect,
     TextDelta,
@@ -954,7 +955,12 @@ pub struct Daemon {
 
 impl Daemon {
     // Launch the daemon. Optionally, connect to given peer.
-    pub async fn new(app_config: AppConfig, init: bool, persist: bool) -> Result<Self> {
+    pub async fn new(
+        app_config: AppConfig,
+        init: bool,
+        persist: bool,
+        ui: &UserInterface,
+    ) -> Result<Self> {
         let is_host = app_config.is_host();
 
         let document_handle = DocumentActorHandle::new(&app_config, init, is_host, persist);
@@ -965,7 +971,7 @@ impl Daemon {
         let socket_path = base_dir
             .join(config::CONFIG_DIR)
             .join(config::DEFAULT_SOCKET_NAME);
-        editor::spawn_socket_listener(&socket_path, document_handle.clone())?;
+        editor::spawn_socket_listener(&socket_path, document_handle.clone(), ui)?;
 
         // Start file watcher.
         spawn_file_watcher(&app_config, document_handle.clone());
@@ -977,7 +983,7 @@ impl Daemon {
 
         // Start connection manager.
         let connection_manager =
-            peer::ConnectionManager::new(&app_config, document_handle.clone(), base_dir)
+            peer::ConnectionManager::new(&app_config, document_handle.clone(), base_dir, ui)
                 .await
                 .expect("Failed to start connection manager");
         let address = connection_manager.secret_address();
@@ -994,7 +1000,7 @@ impl Daemon {
             );
         }
         if app_config.emit_join_code {
-            put_secret_address_into_wormhole(address, app_config.magic_wormhole_relay.clone())
+            put_secret_address_into_wormhole(address, app_config.magic_wormhole_relay.clone(), ui)
                 .await;
         }
         if let Some(config::Peer::SecretAddress(ref secret_address)) = app_config.peer {

--- a/crates/teamtype/src/document.rs
+++ b/crates/teamtype/src/document.rs
@@ -96,7 +96,9 @@ impl Document {
 
         // Update files cache.
         for patch in &patches {
-            match PatchEffect::try_from(patch).expect("Should be able to convert to patch effect") {
+            match PatchEffect::try_from_with_ui(patch, &self.ui)
+                .expect("Should be able to convert to patch effect")
+            {
                 PatchEffect::FileChange(file_text_delta) => {
                     let old_text = if let Some(Content::String(old_text)) =
                         self.files.get(&file_text_delta.file_path)

--- a/crates/teamtype/src/document.rs
+++ b/crates/teamtype/src/document.rs
@@ -15,7 +15,7 @@ use automerge::{
     transaction::Transactable,
 };
 use dissimilar::Chunk;
-use tracing::{debug, info};
+use tracing::debug;
 
 use crate::path::RelativePath;
 use crate::types::{EditorTextDelta, PatchEffect, TextDelta, UserInterface};
@@ -39,7 +39,7 @@ pub enum Content {
 pub struct Document {
     files: HashMap<RelativePath, Content>,
     doc: AutoCommit,
-    _ui: UserInterface,
+    ui: UserInterface,
 }
 
 impl Document {
@@ -60,7 +60,7 @@ impl Document {
         let mut result = Self {
             files: HashMap::default(),
             doc,
-            _ui: ui.clone(),
+            ui: ui.clone(),
         };
         result.update_files();
         result
@@ -241,7 +241,8 @@ impl Document {
             }
 
             let text_delta: TextDelta = chunks.into();
-            info!("Detected change of {file_path}. Updating.");
+            self.ui
+                .log(&format!("Detected change of {file_path}. Updating."));
             debug!("Full delta of this update: {text_delta}");
             self.apply_delta_to_doc(&text_delta, file_path).expect("Failed to apply delta to document while updating text. Probably the delta doesn't fit the document content.");
 
@@ -264,7 +265,8 @@ impl Document {
             return;
         }
 
-        info!("Removing {file_path} from the Teamtype history.");
+        self.ui
+            .log(&format!("Removing {file_path} from the Teamtype history."));
 
         // Remove from Automerge document.
         let file_map = self
@@ -281,7 +283,9 @@ impl Document {
     pub fn set_file(&mut self, content: Content, file_path: &RelativePath) {
         match content {
             Content::String(ref text) => {
-                info!("Initializing {file_path} in the Teamtype history.");
+                self.ui.log(&format!(
+                    "Initializing {file_path} in the Teamtype history."
+                ));
                 self.files
                     .insert(file_path.clone(), Content::String(text.clone()));
 
@@ -313,7 +317,9 @@ impl Document {
 
                 // If the file was not in the document before, log this.
                 if !self.file_exists(file_path) {
-                    info!("Initializing binary {file_path} in the Teamtype history.");
+                    self.ui.log(&format!(
+                        "Initializing binary {file_path} in the Teamtype history."
+                    ));
                 }
 
                 self.doc

--- a/crates/teamtype/src/document.rs
+++ b/crates/teamtype/src/document.rs
@@ -17,10 +17,8 @@ use automerge::{
 use dissimilar::Chunk;
 use tracing::{debug, info};
 
-use crate::{
-    path::RelativePath,
-    types::{EditorTextDelta, PatchEffect, TextDelta},
-};
+use crate::path::RelativePath;
+use crate::types::{EditorTextDelta, PatchEffect, TextDelta, UserInterface};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Content {
@@ -41,28 +39,28 @@ pub enum Content {
 pub struct Document {
     files: HashMap<RelativePath, Content>,
     doc: AutoCommit,
+    _ui: UserInterface,
 }
 
-impl Default for Document {
-    fn default() -> Self {
+impl Document {
+    pub fn new(ui: &UserInterface) -> Self {
         // We're baking a single static initial state into the binary rather than generating new documents
         // from a random seed in each client so that documents created by independent peers can be merged.
         // See build.rs for how to force a rebuild of this initial state, but be aware updating the initial
         // state is a breaking change that will make Teamtype peers incompatible with each other.
         // See https://automerge.org/docs/cookbook/modeling-data/#setting-up-an-initial-document-structure
         let initial_automerge_doc_bytes = include_bytes!("initial_automerge_doc.bin");
-        Self::load(initial_automerge_doc_bytes)
+        Self::load(initial_automerge_doc_bytes, ui)
     }
-}
 
-impl Document {
     // TODO: use sth like try_load + Result to bubble up potential errors.
-    pub fn load(bytes: &[u8]) -> Self {
+    pub fn load(bytes: &[u8], ui: &UserInterface) -> Self {
         let doc =
             AutoCommit::load(bytes).expect("Failed to load Automerge document from given bytes");
         let mut result = Self {
             files: HashMap::default(),
             doc,
+            _ui: ui.clone(),
         };
         result.update_files();
         result
@@ -416,6 +414,7 @@ impl Document {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testing::TestInteractions;
     use crate::types::factories::*;
 
     impl Document {
@@ -429,7 +428,8 @@ mod tests {
 
     #[test]
     fn can_initialize_content() {
-        let mut document = Document::default();
+        let ui = &UserInterface::new(TestInteractions {});
+        let mut document = Document::new(ui);
         let text = "To be or not to be, that is the question";
         let file = RelativePath::new("text");
 
@@ -440,7 +440,8 @@ mod tests {
 
     #[test]
     fn can_initialize_content_multifile() {
-        let mut document = Document::default();
+        let ui = &UserInterface::new(TestInteractions {});
+        let mut document = Document::new(ui);
 
         let text = "To be or not to be, that is the question";
         let text2 = "2b||!2b, that is the question";
@@ -457,7 +458,8 @@ mod tests {
 
     #[test]
     fn retrieve_content_file_nonexistent_errs() {
-        let document = Document::default();
+        let ui = &UserInterface::new(TestInteractions {});
+        let document = Document::new(ui);
         assert!(
             document
                 .current_file_content(&RelativePath::new("text"))
@@ -466,7 +468,8 @@ mod tests {
     }
 
     fn apply_delta_to_doc_works(initial: &str, delta: &TextDelta, expected: &str) {
-        let mut document = Document::default();
+        let ui = &UserInterface::new(TestInteractions {});
+        let mut document = Document::new(ui);
         let file = RelativePath::new("text");
 
         document.set_file(Content::String(initial.to_string()), &file);
@@ -514,7 +517,8 @@ mod tests {
 
     #[test]
     fn apply_delta_only_changes_specified_file() {
-        let mut document = Document::default();
+        let ui = &UserInterface::new(TestInteractions {});
+        let mut document = Document::new(ui);
 
         let file1 = RelativePath::new("text");
         let file2 = RelativePath::new("text2");
@@ -536,7 +540,8 @@ mod tests {
 
         #[test]
         fn test_generate_sync_message() {
-            let mut document = Document::default();
+            let ui = &UserInterface::new(TestInteractions {});
+            let mut document = Document::new(ui);
             let mut state = AutomergeSyncState::new();
             assert!(document.generate_sync_message(&mut state).is_some());
             // Stops for now and waits for a response

--- a/crates/teamtype/src/editor.rs
+++ b/crates/teamtype/src/editor.rs
@@ -180,7 +180,7 @@ async fn handle_editor_connection(
     stream: UnixStream,
     document_handle: DocumentActorHandle,
     editor_id: EditorId,
-    _ui: &UserInterface,
+    ui: &UserInterface,
 ) {
     let (stream_read, stream_write) = tokio::io::split(stream);
     let mut reader = FramedRead::new(stream_read, IncomingProtocolCodec);
@@ -189,7 +189,7 @@ async fn handle_editor_connection(
     document_handle
         .send_message(DocMessage::NewEditorConnection(editor_id, writer))
         .await;
-    info!("Editor #{editor_id} connected.");
+    ui.log(&format!("Editor #{editor_id} connected."));
 
     while let Some(message) = reader.next().await {
         match message {

--- a/crates/teamtype/src/editor.rs
+++ b/crates/teamtype/src/editor.rs
@@ -28,6 +28,7 @@ use crate::editor_protocol::{
     EditorProtocolMessageError, IncomingMessage, JSONRPCResponse, OutgoingMessage,
 };
 use crate::sandbox;
+use crate::types::UserInterface;
 
 pub type EditorId = usize;
 
@@ -99,6 +100,7 @@ pub(crate) fn strip_current_dir(path: &Path) -> PathBuf {
 pub fn spawn_socket_listener(
     socket_path: &Path,
     document_handle: DocumentActorHandle,
+    ui: &UserInterface,
 ) -> Result<()> {
     // Make sure the parent directory of the socket is only accessible by the current user.
     if let Err(description) = is_user_readable_only(socket_path) {
@@ -142,20 +144,32 @@ pub fn spawn_socket_listener(
     env::set_current_dir(previous_cwd)?;
     debug!("Listening on UNIX socket: {}", socket_path.display());
 
-    tokio::spawn(async move {
-        loop {
-            match listener.accept().await {
-                Ok((stream, _addr)) => {
-                    let id = document_handle.clone().next_editor_id();
-                    let document_handle_clone = document_handle.clone();
-                    tokio::spawn(async move {
-                        handle_editor_connection(stream, document_handle_clone.clone(), id).await;
-                    })
-                }
-                Err(err) => {
-                    panic!("Error while accepting socket connection: {err}");
-                }
-            };
+    tokio::spawn({
+        let ui = ui.clone();
+        async move {
+            loop {
+                match listener.accept().await {
+                    Ok((stream, _addr)) => {
+                        let id = document_handle.clone().next_editor_id();
+                        let document_handle_clone = document_handle.clone();
+                        tokio::spawn({
+                            let ui = ui.clone();
+                            async move {
+                                handle_editor_connection(
+                                    stream,
+                                    document_handle_clone.clone(),
+                                    id,
+                                    &ui,
+                                )
+                                .await;
+                            }
+                        })
+                    }
+                    Err(err) => {
+                        panic!("Error while accepting socket connection: {err}");
+                    }
+                };
+            }
         }
     });
 
@@ -166,6 +180,7 @@ async fn handle_editor_connection(
     stream: UnixStream,
     document_handle: DocumentActorHandle,
     editor_id: EditorId,
+    _ui: &UserInterface,
 ) {
     let (stream_read, stream_write) = tokio::io::split(stream);
     let mut reader = FramedRead::new(stream_read, IncomingProtocolCodec);

--- a/crates/teamtype/src/editor.rs
+++ b/crates/teamtype/src/editor.rs
@@ -21,7 +21,7 @@ use tokio_util::{
     bytes::BytesMut,
     codec::{Decoder, Encoder, FramedRead, FramedWrite, LinesCodec},
 };
-use tracing::{debug, info};
+use tracing::debug;
 
 use crate::daemon::{DocMessage, DocumentActorHandle};
 use crate::editor_protocol::{
@@ -180,7 +180,7 @@ async fn handle_editor_connection(
     stream: UnixStream,
     document_handle: DocumentActorHandle,
     editor_id: EditorId,
-    _ui: &UserInterface,
+    ui: &UserInterface,
 ) {
     let (stream_read, stream_write) = tokio::io::split(stream);
     let mut reader = FramedRead::new(stream_read, IncomingProtocolCodec);
@@ -189,7 +189,7 @@ async fn handle_editor_connection(
     document_handle
         .send_message(DocMessage::NewEditorConnection(editor_id, writer))
         .await;
-    info!("Editor #{editor_id} connected.");
+    ui.log(&format!("Editor #{editor_id} connected."));
 
     while let Some(message) = reader.next().await {
         match message {
@@ -221,5 +221,5 @@ async fn handle_editor_connection(
     document_handle
         .send_message(DocMessage::CloseEditorConnection(editor_id))
         .await;
-    info!("Editor #{editor_id} disconnected.");
+    ui.log(&format!("Editor #{editor_id} disconnected."));
 }

--- a/crates/teamtype/src/editor.rs
+++ b/crates/teamtype/src/editor.rs
@@ -21,7 +21,7 @@ use tokio_util::{
     bytes::BytesMut,
     codec::{Decoder, Encoder, FramedRead, FramedWrite, LinesCodec},
 };
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info};
 
 use crate::daemon::{DocMessage, DocumentActorHandle};
 use crate::editor_protocol::{
@@ -120,7 +120,7 @@ pub fn spawn_socket_listener(
                 "Detected an existing daemon running for this directory. Rejecting to start another one."
             );
         }
-        warn!(
+        ui.warn(
             "An existing socket was found for this directory, but since the daemon seems to be defunct it is being removed."
         );
         sandbox::remove_file(Path::new("/"), socket_path).expect("Could not remove socket");
@@ -207,7 +207,7 @@ async fn handle_editor_connection(
                         data: None,
                     },
                 };
-                error!("Error for JSON-RPC request: {:?}", response);
+                ui.warn(&format!("Error for JSON-RPC request: {response:?}"));
                 let message = OutgoingMessage::Response(response);
                 document_handle
                     .send_message(DocMessage::ToEditor(editor_id, message))

--- a/crates/teamtype/src/lib.rs
+++ b/crates/teamtype/src/lib.rs
@@ -18,6 +18,7 @@ pub mod ot;
 pub mod path;
 pub mod peer;
 pub mod sandbox;
+pub mod traits;
 pub mod types;
 pub mod watcher;
 pub mod wormhole;

--- a/crates/teamtype/src/lib.rs
+++ b/crates/teamtype/src/lib.rs
@@ -22,3 +22,6 @@ pub mod traits;
 pub mod types;
 pub mod watcher;
 pub mod wormhole;
+
+#[cfg(test)]
+pub(crate) mod testing;

--- a/crates/teamtype/src/main.rs
+++ b/crates/teamtype/src/main.rs
@@ -5,8 +5,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::io::Write;
-use std::io::{stdin, stdout};
 use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::{env, panic};
@@ -312,7 +310,7 @@ fn get_directory(temporary_directory: Option<&TempDir>, cli: &Cli) -> Result<Pat
 fn setup_teamtype_directory(
     directory: &Path,
     temporary_directory: Option<&TempDir>,
-    _ui: &UserInterface,
+    ui: &UserInterface,
 ) -> Result<()> {
     if has_ethersync_directory(directory) {
         let old_directory = directory.join(config::LEGACY_CONFIG_DIR);
@@ -322,7 +320,7 @@ fn setup_teamtype_directory(
             &old_directory.display()
         );
 
-        if prompt_bool(&format!(
+        if ui.confirm(&format!(
             "Do you want to rename {}/ to {}/?",
             config::LEGACY_CONFIG_DIR,
             config::CONFIG_DIR,
@@ -351,7 +349,7 @@ fn setup_teamtype_directory(
                 &directory.display()
             );
 
-            if prompt_bool(&format!(
+            if ui.confirm(&format!(
                 "Do you want to enable live collaboration here? (This will create an {}/ directory.)",
                 config::CONFIG_DIR
             ))? {
@@ -367,18 +365,4 @@ fn setup_teamtype_directory(
 
 fn get_current_directory() -> Result<PathBuf> {
     env::current_dir().context("Could not access current directory")
-}
-
-fn prompt_bool(question: &str) -> Result<bool> {
-    print!("{question} (y/N): ");
-    stdout().flush()?;
-    let mut lines = stdin().lines();
-    if let Some(Ok(line)) = lines.next() {
-        match line.to_lowercase().as_str() {
-            "y" | "yes" => Ok(true),
-            _ => Ok(false),
-        }
-    } else {
-        bail!("Failed to read answer");
-    }
 }

--- a/crates/teamtype/src/main.rs
+++ b/crates/teamtype/src/main.rs
@@ -23,7 +23,7 @@ use teamtype::{
 };
 use tempfile::{TempDir, tempdir_in};
 use tokio::signal;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use self::cli::{Cli, Commands, ShareJoinFlags};
 
@@ -104,7 +104,7 @@ async fn run_daemon(app_config: AppConfig, init_doc: bool, ui: &UserInterface) -
     config::ensure_teamtype_is_ignored(&app_config.base_dir)?;
 
     if app_config.sync_vcs && config::has_local_user_config(&app_config.base_dir).is_ok_and(|v| v) {
-        warn!(docstr!(
+        ui.warn(docstr!(
             /// You have a local user configuration in your .git/config.
             /// In --sync-vcs mode, this file will also be synchronized between peers.
             /// If your version "wins", all peers will have the same Git identity.
@@ -211,7 +211,7 @@ async fn run_client(directory: PathBuf) -> Result<()> {
         .context("JSON-RPC forwarder failed")
 }
 
-async fn trap_shutdown(_ui: &UserInterface) {
+async fn trap_shutdown(ui: &UserInterface) {
     let interruption = async {
         signal::ctrl_c()
             .await
@@ -231,10 +231,10 @@ async fn trap_shutdown(_ui: &UserInterface) {
 
     tokio::select! {
         () = interruption => {
-            info!("Got SIGINT (Ctrl+C), shutting down");
+            ui.inform("Got SIGINT (Ctrl+C), shutting down");
         }
         () = termination => {
-            info!("Got SIGTERM, shutting down");
+            ui.inform("Got SIGTERM, shutting down");
         }
     }
 }
@@ -315,13 +315,11 @@ fn setup_teamtype_directory(
     if has_ethersync_directory(directory) {
         let old_directory = directory.join(config::LEGACY_CONFIG_DIR);
 
-        warn!(
-            "You have an '{}/' directory, back from when the project was called \"Ethersync\" until October 2025.",
-            &old_directory.display()
-        );
-
-        if ui.confirm(&format!(
-            "Do you want to rename {}/ to {}/?",
+        if ui.confirm(&docstr!(format!
+            /// You have an '{}/' directory, back from when the project was called \"Ethersync\" until October 2025.
+            ///
+            /// Do you want to rename {}/ to {}/?
+            config::LEGACY_CONFIG_DIR,
             config::LEGACY_CONFIG_DIR,
             config::CONFIG_DIR,
         ))? {
@@ -343,21 +341,17 @@ fn setup_teamtype_directory(
                 &directory.display()
             );
             sandbox::create_dir(directory, &teamtype_dir)?;
+        } else if ui.confirm(&docstr!(format!
+            /// '{}' hasn't been used as a Teamtype directory before.
+            ///
+            /// Do you want to enable live collaboration here? (This will create an {}/ directory.)
+            directory.display(),
+            config::CONFIG_DIR
+        ))? {
+            sandbox::create_dir(directory, &teamtype_dir)?;
+            info!("Created! Resuming launch.");
         } else {
-            warn!(
-                "'{}' hasn't been used as a Teamtype directory before.",
-                &directory.display()
-            );
-
-            if ui.confirm(&format!(
-                "Do you want to enable live collaboration here? (This will create an {}/ directory.)",
-                config::CONFIG_DIR
-            ))? {
-                sandbox::create_dir(directory, &teamtype_dir)?;
-                info!("Created! Resuming launch.");
-            } else {
-                bail!("Aborting launch. Teamtype needs a .teamtype/ directory to function");
-            }
+            bail!("Aborting launch. Teamtype needs a .teamtype/ directory to function");
         }
     }
     Ok(())

--- a/crates/teamtype/src/main.rs
+++ b/crates/teamtype/src/main.rs
@@ -65,11 +65,11 @@ async fn main() -> Result<()> {
 
     logging::initialize().context("Failed to initialize logging")?;
 
-    let _ui = &UserInterface::new(ConsoleInteractions {});
+    let ui = &UserInterface::new(ConsoleInteractions {});
 
     let temporary_directory = get_temporary_directory(&cli)?;
     let directory = get_directory(temporary_directory.as_ref(), &cli)?;
-    setup_teamtype_directory(&directory, temporary_directory.as_ref())
+    setup_teamtype_directory(&directory, temporary_directory.as_ref(), ui)
         .context("Failed to find .teamtype/ directory")?;
 
     // TODO: If the result of this joined future handles were to go out of scope and hence be
@@ -80,21 +80,21 @@ async fn main() -> Result<()> {
     let _handle = match cli.command {
         Commands::Client => return run_client(directory.clone()).await,
         Commands::Join { .. } => {
-            let join_config = parse_join_config(cli.command, directory.clone()).await?;
-            run_daemon(join_config, false).await
+            let join_config = parse_join_config(cli.command, directory.clone(), ui).await?;
+            run_daemon(join_config, false, ui).await
         }
         Commands::Share { init, .. } => {
-            let share_config = parse_share_config(cli.command, directory.clone());
-            run_daemon(share_config, init).await
+            let share_config = parse_share_config(cli.command, directory.clone(), ui);
+            run_daemon(share_config, init, ui).await
         }
     }?;
 
-    trap_shutdown().await;
+    trap_shutdown(ui).await;
 
     Ok(())
 }
 
-async fn run_daemon(app_config: AppConfig, init_doc: bool) -> Result<Daemon> {
+async fn run_daemon(app_config: AppConfig, init_doc: bool, ui: &UserInterface) -> Result<Daemon> {
     let persist = !config::has_git_remote(&app_config.base_dir);
     if !persist {
         // TODO: drop .teamtype/doc here? Would that be rude?
@@ -119,12 +119,16 @@ async fn run_daemon(app_config: AppConfig, init_doc: bool) -> Result<Daemon> {
     // Setup a new daemon from the derived config. Immediately join the handle because that's what
     // actually starts the local socket and any configured network connections. Return the result
     // so the calling context can determine when to terminate.
-    Daemon::new(app_config, init_doc, persist)
+    Daemon::new(app_config, init_doc, persist, ui)
         .await
         .context("Failed to launch the daemon")
 }
 
-async fn parse_join_config(command: Commands, directory: PathBuf) -> Result<AppConfig> {
+async fn parse_join_config(
+    command: Commands,
+    directory: PathBuf,
+    ui: &UserInterface,
+) -> Result<AppConfig> {
     if let Commands::Join {
         join_code,
         shared_flags:
@@ -152,9 +156,9 @@ async fn parse_join_config(command: Commands, directory: PathBuf) -> Result<AppC
             sync_vcs,
             username,
         };
-        let mut app_config = AppConfig::from_config_file_and_cli(app_config_cli);
+        let mut app_config = AppConfig::from_config_file_and_cli(app_config_cli, ui);
         app_config = app_config
-            .resolve_peer()
+            .resolve_peer(ui)
             .await
             .context("Failed to resolve peer")?;
         Ok(app_config)
@@ -163,7 +167,7 @@ async fn parse_join_config(command: Commands, directory: PathBuf) -> Result<AppC
     }
 }
 
-fn parse_share_config(command: Commands, directory: PathBuf) -> AppConfig {
+fn parse_share_config(command: Commands, directory: PathBuf, ui: &UserInterface) -> AppConfig {
     if let Commands::Share {
         no_join_code,
         shared_flags:
@@ -192,7 +196,7 @@ fn parse_share_config(command: Commands, directory: PathBuf) -> AppConfig {
             sync_vcs,
             username,
         };
-        let mut app_config = AppConfig::from_config_file_and_cli(app_config_cli);
+        let mut app_config = AppConfig::from_config_file_and_cli(app_config_cli, ui);
         // Because of the "share" subcommand, explicitly don't connect anywhere.
         app_config.peer = None;
         app_config
@@ -209,7 +213,7 @@ async fn run_client(directory: PathBuf) -> Result<()> {
         .context("JSON-RPC forwarder failed")
 }
 
-async fn trap_shutdown() {
+async fn trap_shutdown(_ui: &UserInterface) {
     let interruption = async {
         signal::ctrl_c()
             .await
@@ -305,7 +309,11 @@ fn get_directory(temporary_directory: Option<&TempDir>, cli: &Cli) -> Result<Pat
     Ok(directory)
 }
 
-fn setup_teamtype_directory(directory: &Path, temporary_directory: Option<&TempDir>) -> Result<()> {
+fn setup_teamtype_directory(
+    directory: &Path,
+    temporary_directory: Option<&TempDir>,
+    _ui: &UserInterface,
+) -> Result<()> {
     if has_ethersync_directory(directory) {
         let old_directory = directory.join(config::LEGACY_CONFIG_DIR);
 

--- a/crates/teamtype/src/main.rs
+++ b/crates/teamtype/src/main.rs
@@ -23,7 +23,7 @@ use teamtype::{
 };
 use tempfile::{TempDir, tempdir_in};
 use tokio::signal;
-use tracing::{debug, info};
+use tracing::debug;
 
 use self::cli::{Cli, Commands, ShareJoinFlags};
 
@@ -96,7 +96,7 @@ async fn run_daemon(app_config: AppConfig, init_doc: bool, ui: &UserInterface) -
     let persist = !config::has_git_remote(&app_config.base_dir);
     if !persist {
         // TODO: drop .teamtype/doc here? Would that be rude?
-        info!(
+        ui.log(
             "Detected a Git remote: Assuming a pair-programming use-case and starting a new history."
         );
     }
@@ -336,10 +336,10 @@ fn setup_teamtype_directory(
         let teamtype_dir = directory.join(config::CONFIG_DIR);
         let directory_is_temporary_directory = temporary_directory.is_some();
         if directory_is_temporary_directory {
-            info!(
+            ui.log(&format!(
                 "'{}' is the temporary directory that is used as a Teamtype directory.",
-                &directory.display()
-            );
+                directory.display()
+            ));
             sandbox::create_dir(directory, &teamtype_dir)?;
         } else if ui.confirm(&docstr!(format!
             /// '{}' hasn't been used as a Teamtype directory before.
@@ -349,7 +349,7 @@ fn setup_teamtype_directory(
             config::CONFIG_DIR
         ))? {
             sandbox::create_dir(directory, &teamtype_dir)?;
-            info!("Created! Resuming launch.");
+            ui.log("Created! Resuming launch.");
         } else {
             bail!("Aborting launch. Teamtype needs a .teamtype/ directory to function");
         }

--- a/crates/teamtype/src/main.rs
+++ b/crates/teamtype/src/main.rs
@@ -17,6 +17,7 @@ use clap::{CommandFactory as _, FromArgMatches as _};
 use docstr::docstr;
 use microxdg::XdgApp;
 use teamtype::jsonrpc_forwarder::{JSONRPCForwarder, UnixJSONRPCForwarder};
+use teamtype::types::UserInterface;
 use teamtype::{
     config::{self, AppConfig},
     daemon::Daemon,
@@ -29,6 +30,9 @@ use tracing::{debug, info, warn};
 use self::cli::{Cli, Commands, ShareJoinFlags};
 
 mod cli;
+mod cli_ui;
+
+use cli_ui::ConsoleInteractions;
 
 fn has_ethersync_directory(dir: &Path) -> bool {
     let ethersync_dir = dir.join(config::LEGACY_CONFIG_DIR);
@@ -60,6 +64,8 @@ async fn main() -> Result<()> {
     };
 
     logging::initialize().context("Failed to initialize logging")?;
+
+    let _ui = &UserInterface::new(ConsoleInteractions {});
 
     let temporary_directory = get_temporary_directory(&cli)?;
     let directory = get_directory(temporary_directory.as_ref(), &cli)?;

--- a/crates/teamtype/src/peer.rs
+++ b/crates/teamtype/src/peer.rs
@@ -31,6 +31,7 @@ use url::Url;
 use self::sync::{Connection, PeerMessage, SyncActor};
 use crate::config::AppConfig;
 use crate::daemon::DocumentActorHandle;
+use crate::types::UserInterface;
 
 mod sync;
 
@@ -75,6 +76,7 @@ impl ConnectionManager {
         app_config: &AppConfig,
         document_handle: DocumentActorHandle,
         base_dir: &Path,
+        ui: &UserInterface,
     ) -> Result<Self> {
         let (message_tx, message_rx) = mpsc::channel(1);
 
@@ -89,6 +91,7 @@ impl ConnectionManager {
             message_tx.clone(),
             document_handle,
             my_passphrase,
+            ui,
         );
 
         tokio::spawn(async move { actor.run().await });
@@ -240,6 +243,7 @@ struct EndpointActor {
     message_tx: mpsc::Sender<EndpointMessage>,
     document_handle: DocumentActorHandle,
     my_passphrase: SecretKey,
+    ui: UserInterface,
 }
 
 impl EndpointActor {
@@ -249,6 +253,7 @@ impl EndpointActor {
         message_tx: mpsc::Sender<EndpointMessage>,
         document_handle: DocumentActorHandle,
         my_passphrase: SecretKey,
+        ui: &UserInterface,
     ) -> Self {
         Self {
             endpoint,
@@ -256,6 +261,7 @@ impl EndpointActor {
             message_tx,
             document_handle,
             my_passphrase,
+            ui: ui.clone(),
         }
     }
 
@@ -276,15 +282,21 @@ impl EndpointActor {
                                 .send(Err(err.into()))
                                 .expect("Connect receiver dropped");
                         }
-                        Self::reconnect(self.message_tx.clone(), secret_address, previous_attempts)
-                            .await
-                            .expect("Failed to initiate reconnection");
+                        Self::reconnect(
+                            self.message_tx.clone(),
+                            secret_address,
+                            previous_attempts,
+                            &self.ui,
+                        )
+                        .await
+                        .expect("Failed to initiate reconnection");
                         // Not really Ok, but Ok enough.
                         return Ok(());
                     }
                 };
 
-                info!("Connected to peer: {}", conn.remote_id());
+                let endpoint_id = conn.remote_id();
+                info!("Connected to peer: {endpoint_id}");
 
                 if let Some(response_tx) = response_tx {
                     response_tx.send(Ok(())).expect("Connect receiver dropped");
@@ -292,19 +304,22 @@ impl EndpointActor {
 
                 let document_handle_clone = self.document_handle.clone();
                 let message_tx_clone = self.message_tx.clone();
-                tokio::spawn(async move {
-                    if let Err(err) = Self::handle_peer(
-                        document_handle_clone,
-                        conn,
-                        PeerAuth::YourPassphrase(secret_address.passphrase.clone()),
-                    )
-                    .await
-                    {
-                        debug!("Error while handling a peer: {:?}", err);
-                    }
-                    Self::reconnect(message_tx_clone, secret_address, 0)
+                tokio::spawn({
+                    let ui = self.ui.clone();
+                    async move {
+                        if let Err(err) = Self::handle_peer(
+                            document_handle_clone,
+                            conn,
+                            PeerAuth::YourPassphrase(secret_address.passphrase.clone()),
+                        )
                         .await
-                        .expect("Failed to initiate reconnection");
+                        {
+                            debug!("Error while handling a peer: {:?}", err);
+                        }
+                        Self::reconnect(message_tx_clone, secret_address, 0, &ui)
+                            .await
+                            .expect("Failed to initiate reconnection");
+                    }
                 });
             }
         }
@@ -315,19 +330,15 @@ impl EndpointActor {
         message_tx: mpsc::Sender<EndpointMessage>,
         secret_address: SecretAddress,
         previous_attempts: usize,
+        _ui: &UserInterface,
     ) -> Result<()> {
         // Only log at "info" level if this is the first reconnection attempt.
+        let endpoint_id = secret_address.endpoint_addr.id;
         if previous_attempts == 0 {
-            info!(
-                "Connection to peer {} lost, will keep trying to reconnect...",
-                secret_address.endpoint_addr.id
-            );
+            info!("Connection to peer {endpoint_id} lost, will keep trying to reconnect...");
         } else {
             sleep(Duration::from_secs(10)).await;
-            debug!(
-                "Making another attempt to connect to peer {}...",
-                secret_address.endpoint_addr.id
-            );
+            debug!("Making another attempt to connect to peer {endpoint_id}...");
         }
         // We don't need to be notified, so we don't need to use the response channel.
         message_tx
@@ -383,18 +394,21 @@ impl EndpointActor {
 
         let my_passphrase_clone = self.my_passphrase.clone();
         let document_handle_clone = self.document_handle.clone();
-        tokio::spawn(async move {
-            if let Err(err) = Self::handle_peer(
-                document_handle_clone,
-                conn,
-                PeerAuth::MyPassphrase(my_passphrase_clone),
-            )
-            .await
-            {
-                warn!("Incoming connection failed: {err}");
-            }
+        tokio::spawn({
+            let _ui = self.ui.clone();
+            async move {
+                if let Err(err) = Self::handle_peer(
+                    document_handle_clone,
+                    conn,
+                    PeerAuth::MyPassphrase(my_passphrase_clone),
+                )
+                .await
+                {
+                    warn!("Incoming connection failed: {err}");
+                }
 
-            info!("Peer disconnected: {endpoint_id}",);
+                info!("Peer disconnected: {endpoint_id}",);
+            }
         });
     }
 

--- a/crates/teamtype/src/peer.rs
+++ b/crates/teamtype/src/peer.rs
@@ -25,7 +25,7 @@ use iroh::{Endpoint, EndpointAddr, PublicKey, RelayMap, RelayUrl, SecretKey};
 use postcard::{from_bytes, to_allocvec};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::sleep;
-use tracing::{debug, info, warn};
+use tracing::debug;
 use url::Url;
 
 use self::sync::{Connection, PeerMessage, SyncActor};
@@ -296,7 +296,7 @@ impl EndpointActor {
                 };
 
                 let endpoint_id = conn.remote_id();
-                info!("Connected to peer: {endpoint_id}");
+                self.ui.inform(&format!("Connected to peer: {endpoint_id}"));
 
                 if let Some(response_tx) = response_tx {
                     response_tx.send(Ok(())).expect("Connect receiver dropped");
@@ -330,12 +330,14 @@ impl EndpointActor {
         message_tx: mpsc::Sender<EndpointMessage>,
         secret_address: SecretAddress,
         previous_attempts: usize,
-        _ui: &UserInterface,
+        ui: &UserInterface,
     ) -> Result<()> {
         // Only log at "info" level if this is the first reconnection attempt.
         let endpoint_id = secret_address.endpoint_addr.id;
         if previous_attempts == 0 {
-            info!("Connection to peer {endpoint_id} lost, will keep trying to reconnect...");
+            ui.inform(&format!(
+                "Connection to peer {endpoint_id} lost, will keep trying to reconnect..."
+            ));
         } else {
             sleep(Duration::from_secs(10)).await;
             debug!("Making another attempt to connect to peer {endpoint_id}...");
@@ -390,12 +392,12 @@ impl EndpointActor {
     fn handle_incoming_connection(&self, conn: IrohEndpointConnection) {
         let endpoint_id = conn.remote_id();
 
-        info!("Peer connected: {}", &endpoint_id);
+        self.ui.inform(&format!("Peer connected: {endpoint_id}"));
 
         let my_passphrase_clone = self.my_passphrase.clone();
         let document_handle_clone = self.document_handle.clone();
         tokio::spawn({
-            let _ui = self.ui.clone();
+            let ui = self.ui.clone();
             async move {
                 if let Err(err) = Self::handle_peer(
                     document_handle_clone,
@@ -404,10 +406,9 @@ impl EndpointActor {
                 )
                 .await
                 {
-                    warn!("Incoming connection failed: {err}");
+                    ui.warn(&format!("Incoming connection failed: {err}"));
                 }
-
-                info!("Peer disconnected: {endpoint_id}",);
+                ui.inform(&format!("Peer disconnected: {endpoint_id}"));
             }
         });
     }

--- a/crates/teamtype/src/testing.rs
+++ b/crates/teamtype/src/testing.rs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use anyhow::Result;
+
+use crate::traits::Interactions;
+
+// These tests don't look at UI output, they look at what happens to files. This dummy UI
+// implementation just needs to discard everything.
+#[derive(Clone)]
+pub struct TestInteractions {}
+
+impl Interactions for TestInteractions {
+    fn confirm(&self, _question: &str) -> Result<bool> {
+        Ok(false)
+    }
+
+    fn log(&self, _message: &str) {}
+
+    fn inform(&self, _message: &str) {}
+
+    fn warn(&self, _message: &str) {}
+}

--- a/crates/teamtype/src/traits.rs
+++ b/crates/teamtype/src/traits.rs
@@ -16,6 +16,11 @@ pub trait Interactions: Send + Sync {
     /// continuing.
     fn confirm(&self, question: &str) -> Result<bool>;
 
+    /// Log a message that is not essential to function and may only be seen if the user has
+    /// verbose mode enabled or is watching a log file, but could be useful to keep track of what is
+    /// going on.
+    fn log(&self, message: &str);
+
     /// Inform the user about an important bit of information that should be raised to their attention
     /// in whatever UI is relevant for normal operation. This may or may not interrupt a user
     /// depending on whether they look at the relevant bit of interface, but it will be presented

--- a/crates/teamtype/src/traits.rs
+++ b/crates/teamtype/src/traits.rs
@@ -15,4 +15,17 @@ pub trait Interactions: Send + Sync {
     /// Ask the user about some potential action or state change and receive confirmation before
     /// continuing.
     fn confirm(&self, question: &str) -> Result<bool>;
+
+    /// Inform the user about an important bit of information that should be raised to their attention
+    /// in whatever UI is relevant for normal operation. This may or may not interrupt a user
+    /// depending on whether they look at the relevant bit of interface, but it will be presented
+    /// readily available if their attention comes.
+    ///
+    /// These may include messages about new join codes, peer connection and disconnection notices,
+    /// file actions such as remote deletions that might be unexpected, etc.
+    fn inform(&self, message: &str);
+
+    /// Raise a warning message to the users attention in the event that something went sideways and
+    /// may no longer be functioning as expected.
+    fn warn(&self, message: &str);
 }

--- a/crates/teamtype/src/traits.rs
+++ b/crates/teamtype/src/traits.rs
@@ -18,6 +18,19 @@ pub trait Interactions: Send + Sync {
     /// continuing.
     fn confirm(&self, question: &str) -> Result<bool>;
 
+    /// Inform the user about an important bit of information that should be raised to their attention
+    /// in whatever UI is relevant for normal operation. This may or may not interrupt a user
+    /// depending on whether they look at the relevant bit of interface, but it will be presented
+    /// readily available if their attention comes.
+    ///
+    /// These may include messages about new join codes, peer connection and disconnection notices,
+    /// file actions such as remote deletions that might be unexpected, etc.
+    fn inform(&self, message: &str);
+
+    /// Raise a warning message to the users attention in the event that something went sideways and
+    /// may no longer be functioning as expected.
+    fn warn(&self, message: &str);
+
     /// Enable a blanket [`Debug`] implementation for [`UserInterface`] by returning the name of
     /// the UI struct in use.
     fn type_name(&self) -> &'static str {

--- a/crates/teamtype/src/traits.rs
+++ b/crates/teamtype/src/traits.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use anyhow::Result;
+
 /// Defines the ways Teamtype expects to be able to interact with an end user. This includes
 /// printing messages through *to* the user and receiving confirmations *from* them. When using the
 /// CLI interface, these interactions are provided as console functions that interact with the
@@ -9,4 +11,8 @@
 ///
 /// Editors or editor plugins directly linking to Teamtype will need to wire these up to whatever
 /// UI mechanism is available in their context.
-pub trait Interactions: Send + Sync {}
+pub trait Interactions: Send + Sync {
+    /// Ask the user about some potential action or state change and receive confirmation before
+    /// continuing.
+    fn confirm(&self, question: &str) -> Result<bool>;
+}

--- a/crates/teamtype/src/traits.rs
+++ b/crates/teamtype/src/traits.rs
@@ -18,6 +18,11 @@ pub trait Interactions: Send + Sync {
     /// continuing.
     fn confirm(&self, question: &str) -> Result<bool>;
 
+    /// Log a message that is not essential to function and may only be seen if the user has
+    /// verbose mode enabled or is watching a log file, but could be useful to keep track of what is
+    /// going on.
+    fn log(&self, message: &str);
+
     /// Inform the user about an important bit of information that should be raised to their attention
     /// in whatever UI is relevant for normal operation. This may or may not interrupt a user
     /// depending on whether they look at the relevant bit of interface, but it will be presented

--- a/crates/teamtype/src/traits.rs
+++ b/crates/teamtype/src/traits.rs
@@ -4,6 +4,8 @@
 
 use std::any::type_name;
 
+use anyhow::Result;
+
 /// Defines the ways Teamtype expects to be able to interact with an end user. This includes
 /// printing messages through *to* the user and receiving confirmations *from* them. When using the
 /// CLI interface, these interactions are provided as console functions that interact with the
@@ -12,6 +14,10 @@ use std::any::type_name;
 /// Editors or editor plugins directly linking to Teamtype will need to wire these up to whatever
 /// UI mechanism is available in their context.
 pub trait Interactions: Send + Sync {
+    /// Ask the user about some potential action or state change and receive confirmation before
+    /// continuing.
+    fn confirm(&self, question: &str) -> Result<bool>;
+
     /// Enable a blanket [`Debug`] implementation for [`UserInterface`] by returning the name of
     /// the UI struct in use.
     fn type_name(&self) -> &'static str {

--- a/crates/teamtype/src/traits.rs
+++ b/crates/teamtype/src/traits.rs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/// Defines the ways Teamtype expects to be able to interact with an end user. This includes
+/// printing messages through *to* the user and receiving confirmations *from* them. When using the
+/// CLI interface, these interactions are provided as console functions that interact with the
+/// `STDIN` and `STDOUT` streams.
+///
+/// Editors or editor plugins directly linking to Teamtype will need to wire these up to whatever
+/// UI mechanism is available in their context.
+pub trait Interactions: Send + Sync {}

--- a/crates/teamtype/src/traits.rs
+++ b/crates/teamtype/src/traits.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use std::any::type_name;
+
 /// Defines the ways Teamtype expects to be able to interact with an end user. This includes
 /// printing messages through *to* the user and receiving confirmations *from* them. When using the
 /// CLI interface, these interactions are provided as console functions that interact with the
@@ -9,4 +11,10 @@
 ///
 /// Editors or editor plugins directly linking to Teamtype will need to wire these up to whatever
 /// UI mechanism is available in their context.
-pub trait Interactions: Send + Sync {}
+pub trait Interactions: Send + Sync {
+    /// Enable a blanket [`Debug`] implementation for [`UserInterface`] by returning the name of
+    /// the UI struct in use.
+    fn type_name(&self) -> &'static str {
+        type_name::<Self>()
+    }
+}

--- a/crates/teamtype/src/types.rs
+++ b/crates/teamtype/src/types.rs
@@ -18,7 +18,7 @@ use dissimilar::Chunk;
 use operational_transform::{Operation, OperationSeq};
 use ropey::Rope;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, warn};
+use tracing::debug;
 
 use crate::path::RelativePath;
 use crate::traits::Interactions;
@@ -202,11 +202,11 @@ pub enum PatchEffect {
 }
 
 impl PatchEffect {
-    pub fn from_crdt_patches(patches: &[Patch]) -> Vec<Self> {
+    pub fn from_crdt_patches(patches: &[Patch], ui: &UserInterface) -> Vec<Self> {
         let mut file_deltas: Vec<Self> = vec![];
 
         for patch in patches {
-            match patch.try_into() {
+            match Self::try_from_with_ui(patch, ui) {
                 Ok(result) => {
                     file_deltas.push(result);
                 }
@@ -365,10 +365,8 @@ impl TextDelta {
 
 // TODO: This feels like it should go into another file, close to where Document handles writing to
 // the Automerge document. Both places need to know about our chosen structure.
-impl TryFrom<&Patch> for PatchEffect {
-    type Error = Error;
-
-    fn try_from(patch: &Patch) -> Result<Self, Self::Error> {
+impl PatchEffect {
+    pub fn try_from_with_ui(patch: &Patch, ui: &UserInterface) -> Result<Self> {
         fn file_path_from_path_default(path: &[(ObjId, Prop)]) -> Result<RelativePath, Error> {
             if path.len() != 2 {
                 bail!("Unexpected path in Automerge patch, length is not 2");
@@ -412,9 +410,9 @@ impl TryFrom<&Patch> for PatchEffect {
                                         // In this case, the peer receiving this PutMap should
                                         // remove all existing content of this file in open
                                         // editors. So we emit a FileRemovel.
-                                        warn!(
+                                        ui.warn(&format!(
                                             "Resolved conflict for file {relative_path} by overwriting your version."
-                                        );
+                                        ));
                                         Ok(Self::FileRemoval(relative_path))
                                     } else {
                                         // We return an empty delta on the new file, so that the file is created on disk when
@@ -442,9 +440,9 @@ impl TryFrom<&Patch> for PatchEffect {
                                 Prop::Map(file_name) => {
                                     // We assume that conflict resolution works the way, that the
                                     // side that gets the PatchAction is the one that "wins".
-                                    warn!(
+                                    ui.warn(&format!(
                                         "Conflict for file '{file_name}' resolved. Taking your version."
-                                    );
+                                    ));
                                     Ok(Self::NoEffect)
                                 }
                                 Prop::Seq(seq) => {

--- a/crates/teamtype/src/types.rs
+++ b/crates/teamtype/src/types.rs
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use std::borrow::Cow;
+use std::sync::Arc;
 use std::{fmt, vec};
 
 use anyhow::bail;
@@ -12,6 +13,7 @@ use anyhow::{Context, Error, Result};
 use automerge::{
     ConcreteTextValue, ObjId, ObjType, Patch, PatchAction, Prop, ScalarValue, TextEncoding, Value,
 };
+use derive_more::Deref;
 use dissimilar::Chunk;
 use operational_transform::{Operation, OperationSeq};
 use ropey::Rope;
@@ -19,6 +21,23 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
 use crate::path::RelativePath;
+use crate::traits::Interactions;
+
+/// The main UI type for Teamtype is a fairly lightweight wrapper around an [`Arc`] holding some
+/// struct that implements the [`Interactions`] trait. Running any of the listening modes will
+/// require a UI. This should be created early, before even attempting any configuration, and then
+/// passed as an argument to the action functions that require it.
+#[derive(Clone, Deref)]
+pub struct UserInterface(Arc<dyn Interactions>);
+
+impl UserInterface {
+    /// Take any trait object that implements [`Interactions`] and return a reference counting
+    /// pointer to the user interface implementation. This makes it possible to pass a around the UI
+    /// object including by cloning it into Tokio threads.
+    pub fn new(interactions: impl Interactions + 'static) -> Self {
+        Self(Arc::new(interactions))
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TextDelta(pub Vec<TextOp>);

--- a/crates/teamtype/src/types.rs
+++ b/crates/teamtype/src/types.rs
@@ -30,6 +30,12 @@ use crate::traits::Interactions;
 #[derive(Clone, Deref)]
 pub struct UserInterface(Arc<dyn Interactions>);
 
+impl fmt::Debug for UserInterface {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0.type_name())
+    }
+}
+
 impl UserInterface {
     /// Take any trait object that implements [`Interactions`] and return a reference counting
     /// pointer to the user interface implementation. This makes it possible to pass a around the UI

--- a/crates/teamtype/src/wormhole.rs
+++ b/crates/teamtype/src/wormhole.rs
@@ -13,41 +13,51 @@ use tracing::{info, warn};
 
 const NETWORK_RETRY: Duration = Duration::from_mins(5);
 
-pub async fn put_secret_address_into_wormhole(address: &str, magic_wormhole_relay: Option<String>) {
+use crate::types::UserInterface;
+
+pub async fn put_secret_address_into_wormhole(
+    address: &str,
+    magic_wormhole_relay: Option<String>,
+    ui: &UserInterface,
+) {
     let payload: Vec<u8> = address.into();
-    let config = build_magic_wormhole_config(magic_wormhole_relay);
+    let config = build_magic_wormhole_config(magic_wormhole_relay, ui);
 
-    tokio::spawn(async move {
-        loop {
-            let Ok(mailbox_connection) = MailboxConnection::create(config.clone(), 2).await else {
-                warn!(
-                    "Failed to register a new join code via Magic Wormhole. Automatic retry in {:?}. Peers who joined before can still re-connect without a code.",
-                    NETWORK_RETRY
+    tokio::spawn({
+        let _ui = ui.clone();
+        async move {
+            loop {
+                let Ok(mailbox_connection) = MailboxConnection::create(config.clone(), 2).await
+                else {
+                    warn!(
+                        "Failed to register a new join code via Magic Wormhole. Automatic retry in {:?}. Peers who joined before can still re-connect without a code.",
+                        NETWORK_RETRY
+                    );
+                    sleep(NETWORK_RETRY).await;
+                    continue;
+                };
+                let code = mailbox_connection.code().clone();
+
+                info!(
+                    "{}",
+                    &docstr!(format!
+                            /// One other person can use this to connect to you:
+                            ///
+                            ///    teamtype join {code}
+                            ///
+                    )
                 );
-                sleep(NETWORK_RETRY).await;
-                continue;
-            };
-            let code = mailbox_connection.code().clone();
 
-            info!(
-                "{}",
-                &docstr!(format!
-                        /// One other person can use this to connect to you:
-                        ///
-                        ///    teamtype join {code}
-                        ///
-                )
-            );
+                if let Ok(mut wormhole) = Wormhole::connect(mailbox_connection).await {
+                    let _ = wormhole.send(payload.clone()).await;
+                } else {
+                    warn!("Failed to share secret address. Did your peer mistype the join code?");
+                }
 
-            if let Ok(mut wormhole) = Wormhole::connect(mailbox_connection).await {
-                let _ = wormhole.send(payload.clone()).await;
-            } else {
-                warn!("Failed to share secret address. Did your peer mistype the join code?");
+                // Print a new join code in the next iteration of the for loop, to allow more people
+                // to join.
+                sleep(Duration::from_millis(500)).await;
             }
-
-            // Print a new join code in the next iteration of the for loop, to allow more people
-            // to join.
-            sleep(Duration::from_millis(500)).await;
         }
     });
 }
@@ -55,8 +65,9 @@ pub async fn put_secret_address_into_wormhole(address: &str, magic_wormhole_rela
 pub async fn get_secret_address_from_wormhole(
     code: &str,
     magic_wormhole_relay: Option<String>,
+    ui: &UserInterface,
 ) -> Result<String> {
-    let config = build_magic_wormhole_config(magic_wormhole_relay);
+    let config = build_magic_wormhole_config(magic_wormhole_relay, ui);
 
     let mut wormhole =
         Wormhole::connect(MailboxConnection::connect(config, Code::from_str(code)?, false).await?)
@@ -67,6 +78,7 @@ pub async fn get_secret_address_from_wormhole(
 
 fn build_magic_wormhole_config(
     magic_wormhole_relay: Option<String>,
+    _ui: &UserInterface,
 ) -> AppConfig<transfer::AppVersion> {
     let mut config = transfer::APP_CONFIG.id(AppID::new("teamtype"));
 

--- a/crates/teamtype/src/wormhole.rs
+++ b/crates/teamtype/src/wormhole.rs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2025 blinry <mail@blinry.org>
 // SPDX-FileCopyrightText: 2025 zormit <nt4u@kpvn.de>
+// SPDX-FileCopyrightText: 2026 Caleb Maclennan <caleb@alerque.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -9,7 +10,7 @@ use anyhow::Result;
 use docstr::docstr;
 use magic_wormhole::{AppConfig, AppID, Code, MailboxConnection, Wormhole, transfer};
 use tokio::time::sleep;
-use tracing::{info, warn};
+use tracing::info;
 
 const NETWORK_RETRY: Duration = Duration::from_mins(5);
 
@@ -24,34 +25,30 @@ pub async fn put_secret_address_into_wormhole(
     let config = build_magic_wormhole_config(magic_wormhole_relay, ui);
 
     tokio::spawn({
-        let _ui = ui.clone();
+        let ui = ui.clone();
         async move {
             loop {
                 let Ok(mailbox_connection) = MailboxConnection::create(config.clone(), 2).await
                 else {
-                    warn!(
-                        "Failed to register a new join code via Magic Wormhole. Automatic retry in {:?}. Peers who joined before can still re-connect without a code.",
-                        NETWORK_RETRY
-                    );
+                    ui.warn(&format!(
+                    "Failed to register a new join code via Magic Wormhole. Automatic retry in {NETWORK_RETRY:?}. Peers who joined before can still re-connect without a code."
+                ));
                     sleep(NETWORK_RETRY).await;
                     continue;
                 };
                 let code = mailbox_connection.code().clone();
 
-                info!(
-                    "{}",
-                    &docstr!(format!
-                            /// One other person can use this to connect to you:
-                            ///
-                            ///    teamtype join {code}
-                            ///
-                    )
-                );
+                ui.inform(&docstr!(format!
+                    /// One other person can use this to connect to you:
+                    ///
+                    ///    teamtype join {code}
+                    ///
+                ));
 
                 if let Ok(mut wormhole) = Wormhole::connect(mailbox_connection).await {
                     let _ = wormhole.send(payload.clone()).await;
                 } else {
-                    warn!("Failed to share secret address. Did your peer mistype the join code?");
+                    ui.warn("Failed to share secret address. Did your peer mistype the join code?");
                 }
 
                 // Print a new join code in the next iteration of the for loop, to allow more people

--- a/crates/teamtype/src/wormhole.rs
+++ b/crates/teamtype/src/wormhole.rs
@@ -10,7 +10,6 @@ use anyhow::Result;
 use docstr::docstr;
 use magic_wormhole::{AppConfig, AppID, Code, MailboxConnection, Wormhole, transfer};
 use tokio::time::sleep;
-use tracing::info;
 
 const NETWORK_RETRY: Duration = Duration::from_mins(5);
 
@@ -75,12 +74,12 @@ pub async fn get_secret_address_from_wormhole(
 
 fn build_magic_wormhole_config(
     magic_wormhole_relay: Option<String>,
-    _ui: &UserInterface,
+    ui: &UserInterface,
 ) -> AppConfig<transfer::AppVersion> {
     let mut config = transfer::APP_CONFIG.id(AppID::new("teamtype"));
 
     if let Some(url) = magic_wormhole_relay {
-        info!("Using non-default Magic Wormhole relay url {}", url);
+        ui.log(&format!("Using non-default Magic Wormhole relay url {url}"));
         config = config.rendezvous_url(Cow::Owned(url));
     }
     config


### PR DESCRIPTION
This is the substantive replacement for #541 which got overloaded and stripped down to just a small step in this direction.

I'm not sure how much sense this "stack" makes either. I was playing around with GitHub stacks and it made sense when I started the split and less and less as I went on. This should be evaluated in quick succession with the next bits of the stack: #611 and #601. Some of the refactoring here will not make sense until the final commit of #601, and testing intermediate commits will (in some cases) produce duplicate output. The follow up #616 is unrelated and should just be chronologically later.

Since previous discussion is spread out all over the place I'm going to attempt to pull it together here. The following replies are to notes in our dev wiki, plus comments on previous PRs, plus some Zulip threads.

----

> - Idea for the logging PR: Maybe maybe -v the default, and add -q (--quiet)?

I implemented this, but I do not prefer it. I would still prefer to make the default output as direct and to the point as possible so people don't float around in a sea of irrelevant messages when just getting started. That being said I understand tastes differ here and the Unix world is pretty split between apps that default to being verbose and have `--quiet` flags and ones that default to being terse and have `--verbose` flags. If I'm out voted on this point that's fine, but I'd also be quite happy to flip it back around any time before the next tagged release.

> - option 1: keep log levels (info! warn! error!) as they were for now, but make them into ui methods; use debug! for actual logging
>    - calebs main concern: we'd have a ui.warn that we might not need in the future

This is roughly the route I went, but even a step farther. I completely reserved the `tracing` macros for actual logging, and added UI methods `ui.log()`, `ui.inform()`, and `ui.warn()` for everything user facing. The actual output of `ui.log()` output is gated behind the quiet/verbose mode toggle.

> - option 2: iterate on which messages need to go into which levels

I considered this an unsatisfactory option because no matter what level stuff got put in the tracing macros were still getting overloaded for use in a UI, and no amount of shuffling them would enable us to shoehorn them into alternative UIs to the CLI where logging could mix with the console output.

>    - Reason for immediately accepting the "y": deletions might not be handled well in terminals?
>        -> dialoguer seems to allow pressing enter

I switched from `dialoguer` to `inquire` for a couple reasons. I had initially rejected it because we already had most of the dependency tree for `dialoguer` in our SBOM and it was a minimalistic alternative and I thought `inquire` would be heavier. Also I'm less used to using it. It turns out there is some overlap and `tracing-subscriber` and others are already pulling in most of what `inquire` needs anyway.

The interactions for `Confirm` prompts seem more in line with our expectations, and when we need them the other widgets seem pretty nice to use as well.

Lastly `inquire` seems to have better support for Windows terminal nuances. That's going to matter soon.

>    - some warn! ings we had might be "errors" for the user?
>        -> caleb called it ui.error

I have now called it `ui.warn()`, but again only one level of UI function for showing something is wrong. I could not find a good use case for another level. What we do have is user facing errors that are the result of panics or other bubbled up rust errors. I think the wording of `ui.warn()` for things that seem like they might be a concern but we are still running and functioning, and the use of Rust errors for when things go catastrophically wrong is clearer than overloading "error" for both outcomes.


>  I'm surprised by the new (y/n) confirmation behavior where you don't need to press enter anymore. What's your reasoning? Users not realizing that the need to press enter? It will be a bit jarring to old users at first, I think.

The use of `inquire::Confirm` as well as the options I selected both require enter and show typed output instead of toggling a widget state.

> The new (y/n) dialog doesn't look very pretty on my terminal, it seems to "repeat" the question after confirmation on narrow terminals:

Also better handled by `inquire` than `dialoguer`.

> The new -v flag can only be provided directly after teamtype, not after the subcommands, which makes it less discoverable (in the --help entries of the subcommands, for example). Can we promote it to go after share/join, like --directory?

Addressed, the verbosity choice is a global flag.

> With --verbose, the output contains mixed "regular" output and lines with "INFO:" prefix. Seems @zormit also was a bit surprised a bit. From a user perspective, it'd be nice if the messages were formatted the same, probably?

This has been addressed, no log output at all will go to the terminal unless using `RUST_LOG` which is a non standard use case.

> When using --verbose, some messages are duplicated, like the Git username, or the join code.

This is addressed by only using UI not logging functions, but the effect doesn't "take" until #601.

> What is logged as "share code" in one place, we call "join code" instead.

Now only one place.

> I'd miss some messages in the non --verbose mode: Mosty the messages about which files are initialized/changed/deleted. The "Editor #n connected" was also often useful as a confirmation. If all plugins would have a good status display, maybe we wouldn't need it, but I think we're not there yet.

c.f. notes about quiet vs. verbose defaults above.

> Some general thoughts on the design of logging/showing messages to the user:

>   While the "debug" messages probably don't need to be displayed in a user interface in "regular usage", I feel like maybe most messages we previously showed with "info!" should be displayed even in a TUI?

Yes, and most are ported to `ui.log()` where they could be implemented by a TUI.

>    To avoid having to duplicate messages going to the user and going to the logs in the code, might it make sense to have some kind of wrapper that does both?

Yes, done.

----

**Self-review checklist**

- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) pattern, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md) for details how we use it in this project.
- [x] I have manually tested and self-reviewed my changes.
- [x] I have added myself to the REUSE headers in the files where I made significant changes, see [CONTRIBUTING.md](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).
- [x] This PR does not contain content generated by LLMs, see our [generative AI policy](https://github.com/teamtype/teamtype/blob/main/CONTRIBUTING.md).